### PR TITLE
bind console methods to console

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,12 @@
 require('es6-promise').polyfill();
 require('isomorphic-fetch');
 
+Object.keys(console).forEach(function (key) {
+	if (console[key]bind) {
+		console[key] = console[key].bind(console);
+	}
+})
+
 var express = require('express');
 var errorsHandler = require('express-errors-handler');
 var flags = require('next-feature-flags-client');

--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ require('es6-promise').polyfill();
 require('isomorphic-fetch');
 
 Object.keys(console).forEach(function (key) {
-	if (console[key]bind) {
+	if (console[key].bind) {
 		console[key] = console[key].bind(console);
 	}
 })


### PR DESCRIPTION
Useful for development

`.catch(console.log)` not `.catch(function (err) {console.log(err)})`