### PR TITLE
added ability to pass in some metrics config when defining a route

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,17 +75,21 @@ module.exports = function(options) {
 
 	serviceMetrics.init(options.serviceDependencies);
 
-	['get', 'put', 'delete', 'post'].forEach(function (method) {
-		var nativeMethod = app[method];
-		app[method] = function (route, controller, metricsConf) {
-			metricsConf = metricsConf || {};
-			metrics.router.defineRoute(route, metricsConf);
-			return nativeMethod.call(app, route, function (req, res, next) {
-				metrics.router.allocateToRoute(req, res, metricsConf.name || route);
-				return controller(req, res, next);
-			});
-		};
-	});
+	['checkout', 'connect', 'copy', 'delete', 'get', 'head', 'lock', 'merge', 'mkactivity', 'mkcol', 'move', 'm-search', 'notify', 'options', 'patch', 'post', 'propfind', 'proppatch', 'purge', 'put', 'report', 'search', 'subscribe', 'trace', 'unlock', 'unsubscribe']
+		.forEach(function (method) {
+			var nativeMethod = app[method];
+			app[method] = function (route, controller, metricsConf) {
+				if (method === 'get' && arguments.length === 1) {
+					return nativeMethod.call(app, route);
+				}
+				metricsConf = metricsConf || {};
+				metrics.router.defineRoute(method, route, metricsConf);
+				return nativeMethod.call(app, route, function (req, res, next) {
+					metrics.router.allocateToRoute(req, res, method + '_' + (metricsConf.name || route));
+					return controller(req, res, next);
+				});
+			};
+		});
 
 	app.get('/robots.txt', robots);
 	app.get('/__sensu', function(req, res) {


### PR DESCRIPTION
Will need some work in next-metrics too, but the basic idea is

```
app.get('/article/:uuid', controller, {
   name: 'article',
   splitOn: [
     'extension',
     'queryString:fragment',
     'header:x-ft-anonymous'
   ]
}
```

where `splitOn` is an optional ordered list of additional things not covered by the route but which we may care about

If the config is missing (as it will be for all apps right now) then just defaults to using the route regex string as the name of the route

@commuterjoy @matthew-andrews 