### PR TITLE
stop varying on country code for everything

### DIFF
--- a/src/middleware/vary.js
+++ b/src/middleware/vary.js
@@ -10,7 +10,7 @@ function extendVary (val, set) {
 
 module.exports = function(req, res, next) {
 	const resSet = res.set;
-	const varyOn = new Set(['country-code']);
+	const varyOn = new Set([]);
 
 	res.set('vary', Array.from(varyOn).join(', '));
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -65,7 +65,7 @@ describe('simple app', function() {
 		it('set default vary headers', function (done) {
 			request(app)
 				.get('/default-vary')
-				.expect('vary', 'country-code, x-flags, ft-anonymous-user')
+				.expect('vary', 'x-flags, ft-anonymous-user')
 				.expect(200, done);
 
 		});
@@ -73,28 +73,28 @@ describe('simple app', function() {
 		it('extend vary header using single value', function (done) {
 			request(app)
 				.get('/single-vary')
-				.expect('vary', 'country-code, x-flags, ft-anonymous-user, test-vary')
+				.expect('vary', 'x-flags, ft-anonymous-user, test-vary')
 				.expect(200, done);
 		});
 
 		it('extend vary header using vary method', function (done) {
 			request(app)
 				.get('/vary-method')
-				.expect('vary', 'country-code, x-flags, ft-anonymous-user, test-vary')
+				.expect('vary', 'x-flags, ft-anonymous-user, test-vary')
 				.expect(200, done);
 		});
 
 		it('extend vary header using array of values', function (done) {
 			request(app)
 				.get('/array-vary')
-				.expect('vary', 'country-code, x-flags, ft-anonymous-user, test-vary1, test-vary2')
+				.expect('vary', 'x-flags, ft-anonymous-user, test-vary1, test-vary2')
 				.expect(200, done);
 		});
 
 		it('won\'t duplicate vary headers', function (done) {
 			request(app)
 				.get('/duplicate-vary')
-				.expect('vary', 'country-code, x-flags, ft-anonymous-user')
+				.expect('vary', 'x-flags, ft-anonymous-user')
 				.expect(200, done);
 		});
 
@@ -102,7 +102,7 @@ describe('simple app', function() {
 			request(app)
 				.get('/multiple-vary')
 				.expect('test-header', 'is-set')
-				.expect('vary', 'country-code, x-flags, ft-anonymous-user, test-vary')
+				.expect('vary', 'x-flags, ft-anonymous-user, test-vary')
 				.expect(200, done);
 		});
 


### PR DESCRIPTION
@matthew-andrews @ironsidevsquincy 

cc @commuterjoy @ifyio @lc512k Are you explicitly setting vary on country-code headers everywhere you need to in barriers/product-selector etc. After this is merged, by default apps won't vary on country-code