### PR TITLE
Add `hasHeadCss` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 - `withAnonMiddleware` - sets the user's signed in state in the data model, and varies the response accordingly
 - `withBackendAuthentication` - will reject requests not decorated with an `FT-Next-Backend-Key`. *Must be true for any apps accessed via our CDN and router*
 - `withRequestTracing` - enables additional instrumentation of requests and responses to track performance
+- `hasHeadCss` - if the app outputs a `head.css` file, read it (assumes it's in the `public` dir) and store in the `res.locals.headCss`
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 
 ## Cache control

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@financial-times/n-raven": "^2.0.0",
     "@risingstack/trace": "2.5.4",
     "debounce": "^1.0.0",
+    "denodeify": "^1.2.1",
     "express": "^4.10.5",
     "isomorphic-fetch": "^2.0.0",
     "next-feature-flags-client": "^8.4.0",

--- a/src/middleware/head-css.js
+++ b/src/middleware/head-css.js
@@ -5,6 +5,9 @@ module.exports = function(headCssPromise) {
 			.then(function(headCss) {
 				res.locals.headCss = headCss;
 				next();
+			})
+			.catch(function(err) {
+				next(err);
 			});
 	}
 

--- a/src/middleware/head-css.js
+++ b/src/middleware/head-css.js
@@ -1,0 +1,11 @@
+module.exports = function(headCssPromise) {
+
+	return function(req, res, next) {
+		headCssPromise
+			.then(function(headCss) {
+				res.locals.headCss = headCss;
+				next();
+			});
+	}
+
+};


### PR DESCRIPTION
To read the head css file and store in `res.locals.headCss`

Addresses https://github.com/Financial-Times/next-front-page/pull/758#discussion-diff-62103412 - @matthew-andrews 