### PR TITLE
feat(security): allow use of older backend keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ include n.Makefile
 
 test: unit-test verify
 
+unit-test: export FT_NEXT_BACKEND_KEY=test-backend-key
+unit-test: export FT_NEXT_BACKEND_KEY_OLD=test-backend-key-old
+unit-test: export FT_NEXT_BACKEND_KEY_OLDEST=test-backend-key-oldest
 unit-test:
-	export FT_NEXT_BACKEND_KEY=test-backend-key; find test -path '*.test.js' -exec mocha {} +
+	find test -path '*.test.js' -exec mocha {} +
 
 run:
 	node test/fixtures/app/main.js

--- a/main.js
+++ b/main.js
@@ -18,6 +18,16 @@ const serviceMetrics = require('./src/service-metrics');
 const vary = require('./src/middleware/vary');
 const cache = require('./src/middleware/cache');
 const headCssMiddleware = require('./src/middleware/head-css');
+const backendKeys = [];
+if (process.env.FT_NEXT_BACKEND_KEY) {
+	backendKeys.push(process.env.FT_NEXT_BACKEND_KEY);
+}
+if (process.env.FT_NEXT_BACKEND_KEY_OLD) {
+	backendKeys.push(process.env.FT_NEXT_BACKEND_KEY_OLD);
+}
+if (process.env.FT_NEXT_BACKEND_KEY_OLDEST) {
+	backendKeys.push(process.env.FT_NEXT_BACKEND_KEY_OLDEST);
+}
 
 module.exports = function(options) {
 
@@ -90,7 +100,7 @@ module.exports = function(options) {
 				// allow healthchecks etc. through
 				req.path.indexOf('/__') === 0) {
 				next();
-			} else if (req.get('FT-Next-Backend-Key') === process.env.FT_NEXT_BACKEND_KEY) {
+			} else if (backendKeys.indexOf(req.get('FT-Next-Backend-Key')) !== -1) {
 				res.set('FT-Backend-Authentication', true);
 				next();
 			} else {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -89,6 +89,22 @@ describe('simple app', function() {
 				.expect(200, done);
 		});
 
+		it('accepts any request with an older access key (1 older)', function (done) {
+			request(app)
+				.get('/')
+				.set('FT-Next-Backend-Key', 'test-backend-key-old')
+				.expect('FT-Backend-Authentication', /true/)
+				.expect(200, done);
+		});
+
+		it('accepts any request with an older access key (2 older)', function (done) {
+			request(app)
+				.get('/')
+				.set('FT-Next-Backend-Key', 'test-backend-key-oldest')
+				.expect('FT-Backend-Authentication', /true/)
+				.expect(200, done);
+		});
+
 		it('should be possible to disable backend authentication', function (done) {
 			sinon.stub(flags, 'init').returns(Promise.resolve(null));
 			const app = nextExpress({


### PR DESCRIPTION
This commit allows the use of up to 3 backend keys, which allows a grace period for older keys
to be rotated. However, if the environment variables for each key are not set, they will not be used

/cc @matthew-andrews 