### PR TITLE
Resolve the listen promise with created HTTP server

### DIFF
--- a/main.js
+++ b/main.js
@@ -180,7 +180,7 @@ module.exports = function(options) {
 		return Promise.all([flagsPromise, handlebarsPromise, assetsPromise])
 			.then(function() {
 				metrics.count('express.start');
-				actualAppListen.apply(app, args);
+				return actualAppListen.apply(app, args);
 			})
 			.catch(function(err) {
 				// Crash app if flags or handlebars fail


### PR DESCRIPTION
We're looking into using n-express in Origami services, and we need to
get hold of the created HTTP server for use in our integration tests.

I can't envisage this breaking anything in existing services, but then
I'm not that familiar with how you use n-express.

What are people's thoughts?