### PR TITLE
Adds edition to the locals for tracking

### DIFF
--- a/main.js
+++ b/main.js
@@ -100,6 +100,13 @@ module.exports = function(options) {
 		next();
 	});
 
+	// set the edition so it can be added to the html tag and used for tracking
+	app.use(function(req, res, next) {
+		const edition = req.get('ft-edition') || '';
+		app.locals.__edition = edition;
+		next();
+	});
+
 	serviceMetrics.init(options.serviceDependencies);
 
 


### PR DESCRIPTION
We need to send the edition so it can be captured by o-tracking and used
during enrichment.

@matthew-andrews @wheresrhys @tom-parker I am very unfamiliar with `n-express` and `n-ui` so I have just put together two PR's to illustrate what we want to do but I am not sure if there is a better way to do it, so it would be good to talk about this tomorrow if possible.

The second part to this feature is within `n-ui` and is seen here https://github.com/Financial-Times/n-ui/pull/291

 