### PR TITLE
Fix switch edition mobile nav bug

### DIFF
--- a/src/navigation/decorate.js
+++ b/src/navigation/decorate.js
@@ -1,7 +1,9 @@
 "use strict";
+const url = require('url');
 
 function isCurrentLink(item, currentUrl){
-	return (item.href && item.href === currentUrl) || (item.id && currentUrl.includes(item.id));
+	const currentPathName = url.parse(currentUrl).pathname;
+	return (item.href && item.href === currentPathName) || (item.id && currentUrl.includes(item.id));
 }
 
 function decorateItem (item, currentUrl) {

--- a/src/navigation/navigationModel.js
+++ b/src/navigation/navigationModel.js
@@ -1,6 +1,7 @@
 'use strict';
 const Poller = require('ft-poller');
 const ms = require('ms');
+const url = require('url');
 const decorateSelectedLink = require('./decorate');
 const HierarchyMixin = require('./hierarchyMixin');
 
@@ -47,8 +48,9 @@ module.exports = class NavigationModel {
 	}
 
 	static showMobileNav(currentUrl, navData){
+		const currentPathName = url.parse(currentUrl).pathname;
 		for(let item of navData){
-			if(currentUrl === item.href || (item.id && currentUrl.includes(item.id))){
+			if(currentPathName === item.href || (item.id && currentUrl.includes(item.id))){
 				return true;
 			}
 		}

--- a/test/navigation/decorate.test.js
+++ b/test/navigation/decorate.test.js
@@ -41,6 +41,11 @@ describe('Navigation middleware: decorate', () => {
 		expect(clone.drawer.uk[0][2].item.selected).to.be.true;
 	});
 
+	it('ignores query strings in urls when selecting the current item', () => {
+		subject(clone.navbar_mobile.uk, 'navbar_mobile', '/?edition=international');
+		expect(clone.navbar_mobile.uk[0].selected).to.be.true;
+	});
+
 	it('replaces any ${currentPath} placeholders with the given path', () => {
 		subject(clone.account, 'account', '/current-path');
 		expect(clone.account.signin.href).to.not.match(/\$\{\w\}/);

--- a/test/navigation/navigation.test.js
+++ b/test/navigation/navigation.test.js
@@ -83,6 +83,7 @@ describe('Navigation middleware', () => {
 		it('Should not include the mobile nav data if not on a page it links to', () => {
 			const cases = {
 				'/' : true,
+				'/?edition=international' : true,
 				'/fastft' : true,
 				'/stream/brandId/NTlhNzEyMzMtZjBjZi00Y2U1LTg0ODUtZWVjNmEyYmU1NzQ2-QnJhbmRz' : true,
 				'/world': false,


### PR DESCRIPTION
Fix the bug where switching editions meant that the mobile nav no longer got rendered by checking the pathname of the current url rather than the entire url