### PR TITLE
Make the health-checks application name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 - `withBackendAuthentication` - will reject requests not decorated with an `FT-Next-Backend-Key`. *Must be true for any apps accessed via our CDN and router*
 - `hasHeadCss` - if the app outputs a `head.css` file, read it (assumes it's in the `public` dir) and store in the `res.locals.headCss`
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
+- `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.
 
 ## Cache control
 Several useful cache control header values are available as constants on responses:

--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -1,5 +1,9 @@
+'use strict';
+
 module.exports = function (app, options, description) {
 	const healthChecks = options.healthChecks;
+	const defaultAppName = `Next FT.com ${app.locals.__name} in ${process.env.REGION || 'unknown region'}`;
+
 	app.get(/\/__health(?:\.([123]))?$/, function(req, res) {
 		res.set({ 'Cache-Control': 'private, no-cache, max-age=0' });
 		const checks = healthChecks.map(function(check) {
@@ -27,7 +31,7 @@ module.exports = function (app, options, description) {
 		res.set('Content-Type', 'application/json');
 		res.send(JSON.stringify({
 			schemaVersion: 1,
-			name: `Next FT.com ${app.locals.__name} in ${process.env.REGION || 'unknown region'}`,
+			name: options.healthChecksAppName || defaultAppName,
 			systemCode: options.systemCode,
 			description: description,
 			checks: checks


### PR DESCRIPTION
We're using n-express in Origami in a few places and we want to be able
to remove "Next" from the __about endpoint.