### PR TITLE
Allow assets/handlebars to be used without flags

### DIFF
--- a/src/middleware/assets.js
+++ b/src/middleware/assets.js
@@ -84,6 +84,11 @@ Or \`rm -rf bower_components/n-ui && bower install n-ui\` if you're no longer wo
 		}, {}) : {};
 
 	return (req, res, next) => {
+		// This middleware relies on the presence of res.locals.flags.
+		// In some scenarios (e.g. using handlebars but not flags) this
+		// won't be present
+		res.locals.flags = res.locals.flags || {};
+
 		const swCriticalCss = req.get('ft-next-sw') && res.locals.flags.swCriticalCss;
 		// define a helper for adding a link header
 		res.linkResource = constructLinkHeader;


### PR DESCRIPTION
If you create an app with the following config, then the asset middleware will error because `res.locals.flags` is not present:

```js
const app = express({
	withHandlebars: true
});
```

This PR fixes it by setting res.locals.flags if not present.