### PR TITLE
Allow apps to disable preloading assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install -S @financial-times/n-express
 Passed in to `require('@financial-times/n-express')(options)`, these (Booleans defaulting to false unless otherwise stated) turn on various optional features
 - `withFlags` - decorates each request with feature flags as `res.locals.flags`
 - `withHandlebars` - adds handlebars as the rendering engine
+- `withAssets` - adds asset handling middleware, see [Linked Resources (preload)](#linked-resources-preload). Ignored if `withHandlebars` is not `true`
 - `withNavigation` - adds a data model for the navigation to each request (see below)
 - `withNavigationHierarchy` - adds additional data to the navigation model concerning the current page's ancestors and children
 - `withAnonMiddleware` - sets the user's signed in state in the data model, and varies the response accordingly

--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ module.exports = function(options) {
 		withNavigationHierarchy: false,
 		withAnonMiddleware: false,
 		withBackendAuthentication: false,
+		withAssets: options.withHandlebars || false, // TODO always default to false for next major version
 		hasHeadCss: false,
 		hasNUiBundle: false,
 		healthChecks: []
@@ -172,7 +173,9 @@ module.exports = function(options) {
 		}));
 
 		// Decorate responses with data about which assets the page needs
-		app.use(assetsMiddleware(options, directory));
+		if (options.withAssets) {
+			app.use(assetsMiddleware(options, directory));
+		}
 
 		// Handle the akamai -> fastly -> akamai etc. circular redirect bug
 		app.use(function (req, res, next) {


### PR DESCRIPTION
For the Origami services I'm working on, we use the Build Service for assets. The asset preloading causes a stream of 404 errors in the console and canes the server with a lot of requests.

This PR adds a `withoutAssetPreloading` option. Is this something you'd be open to?