### PR TITLE
Move chokidar to production deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@financial-times/n-logger": "^5.0.0",
     "@financial-times/n-polyfill-io": "^1.0.0",
     "@financial-times/n-raven": "^2.0.0",
+    "chokidar": "^1.6.1",
     "date-fns": "^1.3.0",
     "debounce": "^1.0.0",
     "denodeify": "^1.2.1",
@@ -26,7 +27,6 @@
   "devDependencies": {
     "body-parser": "^1.15.0",
     "chai": "^3.0.0",
-    "chokidar": "^1.6.0",
     "eslint": "^2.5.3",
     "fetch-mock": "^5.1.2",
     "lintspaces-cli": "^0.1.1",


### PR DESCRIPTION
It was incorrectly listed as a `devDependency`, even though it is only used in non-production in environment the module loading and eval still happens in all and thus was causing an error.

/cc @bjfletcher 