### PR TITLE
Revert "System code mandatory"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,8 @@ npm install -S @financial-times/n-express
 # API extensions
 
 ## App init options
-
-
 Passed in to `require('@financial-times/n-express')(options)`, these (Booleans defaulting to false unless otherwise stated) turn on various optional features
-
-### Mandatory
-
-- `systemCode` - allows the application to communicate its [CMDB](https://cmdb.ft.com) to other services.
-
-### Optional
-
+- `systemCode` - ensures that the system code is present in the JSON that is returned at the `/__health` endpoint. Note that the value of this property must correspond with the `systemCode` property of the [service registry](http://next-registry.ft.com/) entry of the app in question
 - `withFlags` - decorates each request with feature flags as `res.locals.flags`
 - `withHandlebars` - adds handlebars as the rendering engine
 - `withAssets` - adds asset handling middleware, see [Linked Resources (preload)](#linked-resources-preload). Ignored if `withHandlebars` is not `true`
@@ -30,7 +22,6 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 - `hasHeadCss` - if the app outputs a `head.css` file, read it (assumes it's in the `public` dir) and store in the `res.locals.headCss`
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 - `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.
-
 
 ## Cache control
 Several useful cache control header values are available as constants on responses:

--- a/main.js
+++ b/main.js
@@ -64,10 +64,6 @@ module.exports = function(options) {
 		}
 	});
 
-	if (!options.systemCode) {
-		throw new Error('All applications must specify a CMDB `systemCode` to the express() function. See the README for more details.');
-	}
-
 	let packageJson = {};
 	let name = options.name;
 	let description = '';

--- a/test/anon/anon.test.js
+++ b/test/anon/anon.test.js
@@ -12,7 +12,7 @@ describe('Anonymous Middleware', function() {
 
 	beforeEach(function(){
 		sinon.stub(verifyAssetsExist, 'verify');
-		app = nextExpress({ withFlags:true, withHandlebars:false, withAnonMiddleware:true, systemCode: 'test' });
+		app = nextExpress({ withFlags:true, withHandlebars:false, withAnonMiddleware:true });
 		app.get('/', function(req, res){
 			locals = res.locals;
 			res.sendStatus(200).end();

--- a/test/app/app.test.js
+++ b/test/app/app.test.js
@@ -123,8 +123,7 @@ describe('simple app', function() {
 				name: 'noBackendAuth',
 				directory: __dirname,
 				withHandlebars: false,
-				withBackendAuthentication: false,
-				systemCode: 'test-app'
+				withBackendAuthentication: false
 			});
 			app.get('/let-me-in', function (req, res) {
 				res.end('', 200);
@@ -147,8 +146,7 @@ describe('simple app', function() {
 			name: 'noflags',
 			directory: __dirname,
 			withHandlebars: false,
-			withFlags: false,
-			systemCode: 'test-app'
+			withFlags: false
 		});
 		app.get('/', function (req, res) {
 			res.end('', 200);
@@ -169,8 +167,7 @@ describe('simple app', function() {
 		const app = nextExpress({
 			name: 'nohandles',
 			directory: __dirname,
-			withHandlebars: false,
-			systemCode: 'test-app'
+			withHandlebars: false
 		});
 		app.get('/', function (req, res) {
 			res.end('', 200);
@@ -213,7 +210,6 @@ describe('simple app', function() {
 		function getApp (conf) {
 			conf = conf || {};
 			conf.directory = path.resolve(__dirname, '../fixtures/app/');
-			conf.systemCode = 'test-app';
 			return nextExpress(conf);
 		}
 

--- a/test/fixtures/app/main.js
+++ b/test/fixtures/app/main.js
@@ -15,8 +15,7 @@ const app = module.exports = express({
 	withNavigationHierarchy: true,
 	withAnonMiddleware: true,
 	withBackendAuthentication: true,
-	layoutsDir: __dirname + '/views/',
-	systemCode: 'test-app'
+	layoutsDir: __dirname + '/views/'
 });
 
 app.get('/', function(req, res) {

--- a/test/fixtures/bad-assets/main.js
+++ b/test/fixtures/bad-assets/main.js
@@ -4,8 +4,7 @@ const express = require('../../..');
 const app = module.exports = express({
 	name: 'bad-assets',
 	directory: __dirname,
-	withHandlebars: true,
-	systemCode: 'test'
+	withHandlebars: true
 });
 
 module.exports.listen = app.listen(3000);


### PR DESCRIPTION
Reverts Financial-Times/n-express#413 – this has broken deploys for one of our apps. I'm going to release `v17.15.4` with this removed and then add it back in and release `v18.0.0` afterwards.