### PR TITLE
Allow applications to disable service metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 - `withNavigationHierarchy` - adds additional data to the navigation model concerning the current page's ancestors and children
 - `withAnonMiddleware` - sets the user's signed in state in the data model, and varies the response accordingly
 - `withBackendAuthentication` - will reject requests not decorated with an `FT-Next-Backend-Key`. *Must be true for any apps accessed via our CDN and router*
+- `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
 - `hasHeadCss` - if the app outputs a `head.css` file, read it (assumes it's in the `public` dir) and store in the `res.locals.headCss`
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 - `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ module.exports = function(options) {
 		hasNUiBundle: true,
 		// TODO always default to false for next major version
 		withAssets: options.withHandlebars || false,
+		withServiceMetrics: true,
 		hasHeadCss: false,
 		healthChecks: []
 	};
@@ -142,8 +143,9 @@ module.exports = function(options) {
 		next();
 	});
 
-	serviceMetrics.init(options.serviceDependencies);
-
+	if (options.withServiceMetrics) {
+		serviceMetrics.init(options.serviceDependencies);
+	}
 
 	// Only allow authorized upstream applications access
 	if (options.withBackendAuthentication) {


### PR DESCRIPTION
The Image Service uses fetch in order to request remote images. We can't
provide a list of every image host, and we're seeing errors in Sentry
because of this.

This code makes service metrics optional. I've defaulted the option to
true so that a breaking change isn't introduced.