### PR TITLE
serve assets from www.ft.com

### DIFF
--- a/src/lib/hashed-assets.js
+++ b/src/lib/hashed-assets.js
@@ -19,5 +19,5 @@ module.exports.init = locals => {
 module.exports.get = file => {
 	const fallback = `/${appLocals.__name}/${file}`;
 	const hash = assetHashes[file];
-	return (!appLocals.__isProduction || !hash) ? fallback : `https://next-geebee.ft.com/hashed-assets/${appLocals.__name}/${hash}`;
+	return (!appLocals.__isProduction || !hash) ? fallback : `//www.ft.com/__assets/hashed/${appLocals.__name}/${hash}`;
 }

--- a/src/middleware/assets.js
+++ b/src/middleware/assets.js
@@ -63,7 +63,7 @@ Or \`rm -rf bower_components/n-ui && bower install n-ui\` if you're no longer wo
 				// for normal semver releases prepend a v to the major version
 				nUiUrlRoot = 'v' + nUiRelease.split('.').slice(0,1)[0]
 			}
-			nUiUrlRoot = `//next-geebee.ft.com/n-ui/cached/${nUiUrlRoot}/`;
+			nUiUrlRoot = `//www.ft.com/__assets/n-ui/cached/${nUiUrlRoot}/`;
 		}
 
 	} catch (e) {}

--- a/test/app/app.test.js
+++ b/test/app/app.test.js
@@ -360,7 +360,7 @@ describe('simple app', function() {
 			request(app)
 				.get('/templated')
 				.expect('Link', /<\/\/next-geebee\.ft\.com\/.*polyfill.min\.js.*>; as="script"; rel="preload"; nopush/)
-				.expect('Link', /<\/\/next-geebee\.ft\.com\/n-ui\/cached\/v1\/es5\.min\.js>; as="script"; rel="preload"; nopush/)
+				.expect('Link', /<\/\/www\.ft\.com\/__assets\/n-ui\/cached\/v1\/es5\.min\.js>; as="script"; rel="preload"; nopush/)
 				.expect('Link', /<\/demo-app\/main-without-n-ui\.js>; as="script"; rel="preload"; nopush/, done)
 		});
 


### PR DESCRIPTION
@tavvy @phamann 

kiss goodbye to cors in sw. 

As discussed yesterday, the only remaining resources on geebee will be origami build (for fonts) and polyfill (cc @JakeChampion ) and various images in next-assets, which can now be find&replaced to point at `/__assets/creatives/` (I'm not volunteering myself to do all this, so help would be appreciated)