### PR TITLE
Add ability to decorate response with precache Link headers

### DIFF
--- a/src/middleware/assets.js
+++ b/src/middleware/assets.js
@@ -178,6 +178,12 @@ Or \`rm -rf bower_components/n-ui && bower install n-ui\` if you're no longer wo
 
 				res.locals.cssBundles.forEach(file => res.linkResource(file.path, {as: 'style'}));
 				res.locals.javascriptBundles.forEach(file => res.linkResource(file, {as: 'script'}));
+
+				if (templateData.withAssetPrecache) {
+					res.locals.cssBundles.forEach(file => res.linkResource(file.path, {as: 'style', rel: 'precache'}));
+					res.locals.javascriptBundles.forEach(file => res.linkResource(file, {as: 'script', rel: 'precache'}));
+				}
+
 				return originalRender.apply(res, [].slice.call(arguments));
 			}
 		}


### PR DESCRIPTION
For the offline acceleration month project, we are facilitating the ability to precache sub-resources of a document via a service-worker.

We achieve this by decorating the HTTP response of a document with a `Link` header directive to the resource with a `rel=precache` attribute. The service worker then recursively fetches and caches the declared resources.

This adds the ability for a user to configure this functionality for the core assets of a page (CSS & JS) when calling `res.render()` and hooks into the pre-existing asset middleware.

/cc @wheresrhys @leggsimon @tavvy 