### PR TITLE
Adds a new option `partialsDirectory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 - `hasHeadCss` - if the app outputs a `head.css` file, read it (assumes it's in the `public` dir) and store in the `res.locals.headCss`
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 - `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.
+- `partialsDirectory` String - a path to load partials from, this in addition to the standard `views/partials` that is set for every app
 
 ## Cache control
 Several useful cache control header values are available as constants on responses:

--- a/src/handlebars/index.js
+++ b/src/handlebars/index.js
@@ -6,16 +6,21 @@ module.exports = function (conf) {
 	const directory = conf.directory;
 	const options = conf.options;
 	const helpers = options.helpers || {};
+	const partialsDir = [
+		directory + (options.viewsDirectory || '/views') + '/partials',
+		directory + ('/node_modules/@financial-times')
+	];
 
 	helpers.hashedAsset = function(options) {
 		return hashedAssets.get(options.fn(this));
 	};
 
+	if (options.partialsDirectory) {
+		partialsDir.push(options.partialsDirectory);
+	}
+
 	return handlebars(app, {
-		partialsDir: [
-			directory + (options.viewsDirectory || '/views') + '/partials',
-			directory + ('/node_modules/@financial-times')
-		],
+		partialsDir,
 		defaultLayout: false,
 		// The most common use case, n-ui/layout is not bundled with this package
 		layoutsDir: typeof options.layoutsDir !== 'undefined' ? options.layoutsDir : (directory + '/bower_components/n-ui/layout'),


### PR DESCRIPTION
Will allow an additional path to load partials from.

I have added this as it would be required for pa11y testing of n-ui but
I can also imagine other uses when our normal convention might not
always work.

@wheresrhys @andygnewman Sorry picking on you as you have contributed to this file

/cc @lc512k 