### PR TITLE
Track sigterms

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,3 +255,7 @@ module.exports.static = express.static;
 module.exports.metrics = metrics;
 module.exports.flags = flags;
 module.exports.cacheMiddleware = cache.middleware;
+
+// log https://devcenter.heroku.com/articles/dynos#shutdown
+process.on('SIGTERM', () => metrics.count('express.terminate'));
+process.on('exit', () => metrics.count('express.exit'));


### PR DESCRIPTION
Heroku [sends SIGTERM](https://devcenter.heroku.com/articles/dynos#shutdown) when restarting the applications, which we don't track (we only track express starting).

It's sometimes useful to know if/when the restart has been triggered if the application fails to come back online (say, compared to an uncaught exception).

Eg, all our graphs tracking the outage were missing the fact the outage started at the exact point the sigterm had restarted the processes.

/cc @andygout @wheresrhys 