### PR TITLE
Revert the process exit tracking

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,7 +255,3 @@ module.exports.static = express.static;
 module.exports.metrics = metrics;
 module.exports.flags = flags;
 module.exports.cacheMiddleware = cache.middleware;
-
-// log https://devcenter.heroku.com/articles/dynos#shutdown
-process.on('SIGTERM', () => metrics.count('express.terminate'));
-process.on('exit', () => metrics.count('express.exit'));


### PR DESCRIPTION
It doesn't work consistently and I don't want to start blocking the shutdown process with sync functions (which I think would work).