### PR TITLE
adding model to allow different welcome banner text

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ const backendAuthentication = require('./src/middleware/backend-authentication')
 const NavigationModel = require('./src/navigation/navigationModel');
 const EditionsModel = require('./src/navigation/editionsModel');
 const anon = require('./src/anon');
+const welcomeBannerModelFactory = require('./src/welcome-banner/model');
 
 // Logging and monitoring
 const metrics = require('next-metrics');
@@ -203,6 +204,8 @@ module.exports = function(options) {
 			res.vary('FT-Force-Opt-In-Device');
 			next();
 		});
+
+		app.use(welcomeBannerModelFactory);
 	}
 
 	// Start the app - Woo hoo!

--- a/src/welcome-banner/model.js
+++ b/src/welcome-banner/model.js
@@ -1,3 +1,4 @@
+'use strict';
 
 const defaultWelcomeBannerModel = {
 	title: 'Welcome to the new FT.com',

--- a/src/welcome-banner/model.js
+++ b/src/welcome-banner/model.js
@@ -1,0 +1,40 @@
+
+const defaultWelcomeBannerModel = {
+	title: 'Welcome to the new FT.com',
+	strapline: 'The same global insight. Faster than ever before on all your devices.',
+	ctas : {
+		primary : {
+			text: 'View tips',
+			href: '/tour',
+			trackable: 'tour-page',
+			component: 'cta-take-tour'
+		}
+	}
+};
+
+const compactViewWelcomeBannerModel = {
+	title: 'Try the new compact homepage',
+	strapline: 'A list view of today\'s homepage, with less images',
+	ctas : {
+		primary : {
+			text: 'Try it now',
+			href: '/viewtoggle/compact',
+			trackable: 'compact-view'
+		}
+	}
+};
+
+function welcomeBannerModelFactory (req, res, next){
+	let model;
+	if(res.locals.flags.compactView && req.path === '/' && req.get('FT-Cookie-ft-homepage-view') === 'compact'){
+		model = compactViewWelcomeBannerModel;
+	}else{
+		model = defaultWelcomeBannerModel;
+	}
+
+	res.locals.welcomeBanner = model;
+	next();
+}
+
+module.exports = welcomeBannerModelFactory;
+module.exports._banners = {defaultWelcomeBannerModel, compactViewWelcomeBannerModel};

--- a/src/welcome-banner/model.js
+++ b/src/welcome-banner/model.js
@@ -26,7 +26,7 @@ const compactViewWelcomeBannerModel = {
 };
 
 function welcomeBannerModelFactory (req, res, next){
-	let model;
+	var model;
 	if(res.locals.flags.compactView && req.path === '/' && req.get('FT-Cookie-ft-homepage-view') === 'compact'){
 		model = compactViewWelcomeBannerModel;
 	}else{

--- a/test/welcome-banner/welcome-banner-model.test.js
+++ b/test/welcome-banner/welcome-banner-model.test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const expect = require('chai').expect;
 const sinon = require('sinon');
 

--- a/test/welcome-banner/welcome-banner-model.test.js
+++ b/test/welcome-banner/welcome-banner-model.test.js
@@ -1,0 +1,49 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+describe('Welcome Banner Model', () => {
+
+	let welcomeBannerModelFactory;
+
+	before(() => {
+		welcomeBannerModelFactory = require('../../src/welcome-banner/model');
+	});
+
+	const wait = t => new Promise(r => setTimeout(r, t));
+
+	const testProp = (res, prop, model) => {
+		expect(res.locals.welcomeBanner[prop]).to.deep.equal(welcomeBannerModelFactory._banners[model][prop])
+	};
+
+	const test = (res, model) => {
+		for(let prop of ['title', 'strapline', 'ctas']){
+			testProp(res, prop, model);
+		}
+	};
+
+	it('Should provide the welcome banner model by default', () => {
+		const res = {locals:{flags:{}}};
+		const req = {path:'/', get: () => ''};
+		const next = sinon.spy();
+		welcomeBannerModelFactory(req, res, next);
+		return wait(0).then(() => {
+			sinon.assert.called(next);
+			expect(res.locals).to.have.property('welcomeBanner');
+			test(res, 'defaultWelcomeBannerModel');
+		})
+	});
+
+	it('Should provide the compact view model if the compactView flag is on AND we are on the homepage AND the FT-Cookie-ft-homepage-view is set to "compact"', () => {
+		const res = {locals:{flags:{compactView:true}}};
+		const req = {path:'/', get: () => 'compact'};
+		const next = sinon.spy();
+		welcomeBannerModelFactory(req, res, next);
+		return wait(0).then(() => {
+			sinon.assert.called(next);
+			expect(res.locals).to.have.property('welcomeBanner');
+			test(res, 'compactViewWelcomeBannerModel');
+		})
+	});
+
+
+})


### PR DESCRIPTION
This is so we can use the welcome banner to promote page-specific features (in this the compact homepage)