### PR TITLE
Adds a basic WebPage schema to all requests

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const express = require('express');
 const http = require('http');
 const https = require('https');
 const denodeify = require('denodeify');
+const nextJsonLd = require('next-json-ld');
 
 const flags = require('next-feature-flags-client');
 const backendAuthentication = require('./src/middleware/backend-authentication');
@@ -60,6 +61,7 @@ module.exports = function(options) {
 		withAssets: options.withHandlebars || false,
 		withServiceMetrics: true,
 		hasHeadCss: false,
+		withJsonLd: false,
 		healthChecks: []
 	};
 
@@ -143,6 +145,13 @@ module.exports = function(options) {
 		app.locals.__abState = abState;
 		next();
 	});
+
+	if (options.withJsonLd) {
+		app.use(function(req, res, next) {
+			res.locals.jsonLd = [nextJsonLd.webSite()];
+			next();
+		});
+	}
 
 	if (options.withServiceMetrics) {
 		serviceMetrics.init(options.serviceDependencies);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "isomorphic-fetch": "^2.0.0",
     "ms": "^0.7.1",
     "next-feature-flags-client": "^8.4.0",
+    "next-json-ld": "https://github.com/Financial-Times/next-json-ld",
     "next-metrics": "^1.16.1",
     "node-time": "^0.1.0",
     "semver": "^5.3.0",


### PR DESCRIPTION
This will allow any app that wants to display a basic WebPage schema for
FT pages to do so.

The the templating is handled by `wrapper.html` in `n-ui` and each app
will just need add this data to a `jsonLd` key in the json passed to
render.