### PR TITLE
remove `time` dependency as it is not architecture independant

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "express": "^4.14.0",
     "isomorphic-fetch": "^2.0.0",
     "next-feature-flags-client": "^8.4.0",
-    "next-metrics": "^1.16.1",
-    "time": "^0.11.4"
+    "next-metrics": "^1.16.1"
   },
   "devDependencies": {
     "body-parser": "^1.15.0",

--- a/src/lib/check-failing.js
+++ b/src/lib/check-failing.js
@@ -1,4 +1,3 @@
-const time = require('time');
 const isWithinRange = require('date-fns/is_within_range');
 
 const the = {
@@ -22,7 +21,7 @@ module.exports.fakeCheckFailuresIfApplicable = function (systemCode, checks, req
 		res.send({
 			systemCode,
 			server: {
-				timezone: new time.Date().getTimezone()
+				timezone: new Date().getTimezoneOffset()
 			},
 			state: the,
 			checks


### PR DESCRIPTION
we can't reuse slug built locally on Heroku because of this - you get the `elf` error