### PR TITLE
Add a new caching option that skips stale-while-revalidate

### DIFF
--- a/src/middleware/cache.js
+++ b/src/middleware/cache.js
@@ -1,6 +1,7 @@
 module.exports = (req, res, next) => {
 	res.FT_NO_CACHE = 'max-age=0, no-cache, no-store, must-revalidate';
 	res.FT_SHORT_CACHE = 'max-age=600, stale-while-revalidate=60, stale-if-error=86400';
+	res.FT_SHORT_CACHE_ALWAYS_REVALIDATE = 'max-age=600, stale-if-error=86400';
 	res.FT_HOUR_CACHE = 'max-age=3600, stale-while-revalidate=60, stale-if-error=86400';
 	res.FT_DAY_CACHE = 'max-age=86400, stale-while-revalidate=60, stale-if-error=86400';
 	res.FT_WEEK_CACHE = 'max-age=604800, stale-while-revalidate=60, stale-if-error=259200';


### PR DESCRIPTION
We've realised that on the myFT page `stale-while-revalidate` ain't no good at all for caching pages that'll only ever be accessed by one user (here's a more detailed ramble on my myft-api PR: https://github.com/Financial-Times/next-myft-api/pull/304)

Reckon we'd be justified in adding a next-wide thing for removing it or shall myFT just take this caching into its own hands.

Naming negotiable.