### PR TITLE
disable IP whitelist fallback

### DIFF
--- a/src/middleware/backend-authentication.js
+++ b/src/middleware/backend-authentication.js
@@ -1,5 +1,4 @@
 const nLogger = require('@financial-times/n-logger').default;
-const IpWhitelist = require('../lib/ip-whitelist');
 const metrics = require('next-metrics');
 
 module.exports = (app, appName) => {
@@ -22,8 +21,6 @@ module.exports = (app, appName) => {
 		return;
 	}
 
-	const ipWhitelist = new IpWhitelist();
-
 	app.use((req, res, next) => {
 		// TODO - change how all this works in order to use __assets/app/{appname}
 		// allow static assets, healthchecks, etc., through
@@ -35,10 +32,6 @@ module.exports = (app, appName) => {
 			next();
 		} else if (backendKeys.indexOf(req.get('FT-Next-Backend-Key-Old')) > -1) {
 			metrics.count('express.backend_authentication.old_backend_key');
-			res.set('FT-Backend-Authentication', true);
-			next();
-		} else if (ipWhitelist.validate(req.connection.remoteAddress)) {
-			metrics.count('express.backend_authentication.ip_whitelist');
 			res.set('FT-Backend-Authentication', true);
 			next();
 		} else {


### PR DESCRIPTION
We may use it as an additional security measure, which is why we're not removing the now dead code.