### PR TITLE
Address the sensitive error rate check

### DIFF
--- a/src/lib/error-rate-check.js
+++ b/src/lib/error-rate-check.js
@@ -1,22 +1,19 @@
 const nHealth = require('n-health');
 
-const DEFAULT_THRESHOLD = 0.04;
 const DEFAULT_SEVERITY = 3;
 
 module.exports = (appName, opts) => {
 	opts = opts || {};
-	const threshold = opts.threshold || DEFAULT_THRESHOLD;
 	const severity = opts.severity || DEFAULT_SEVERITY;
 	let region = process.env.REGION ? '_' + process.env.REGION : '';
 	return nHealth.runCheck({
-		name: `500 rate for ${appName} is acceptable (default n-express health check)`,
+		name: `The error rate for ${appName} is acceptable`,
 		type: 'graphiteSpike',
-		numerator: `next.heroku.${appName}.web_*${region}.express.*_GET.res.status.500.count`,
-		divisor: `next.heroku.${appName}.web_*${region}.express.*_GET.res.status.*.count`,
-		threshold,
+		numerator: `next.heroku.${appName}.web_*${region}.express.*.res.status.{500,503,504}.count`,
+		divisor: `next.heroku.${appName}.web_*${region}.express.*.res.status.*.count`,
 		severity,
-		businessImpact: `Error rate for the ${appName} app is higher than the acceptable threshold of ${threshold*100}%.`,
-		technicalSummary: `The proportion of 500 responses for the ${appName} application requests across all heroku dynos vs all responses is higher than a threshold of ${threshold*100}%`,
+		businessImpact: 'Users may see application error pages.',
+		technicalSummary: `The proportion of 500 responses for the ${appName} app is 3 times higher in the last 10 minutes than the error rate over the previous 7 days. This is a default n-express check.`,
 		panicGuide: 'Consult errors in sentry, application logs in splunk and run the application locally to identify errors'
 	});
 };

--- a/test/app/error-rate-check.test.js
+++ b/test/app/error-rate-check.test.js
@@ -28,8 +28,8 @@ describe('Default error rate check', () => {
 	it('should compose correct graphite metric with region', () => {
 		process.env.REGION = 'US';
 
-		const expectedNumerator = 'next.heroku.app-name.web_*_US.express.*_GET.res.status.500.count';
-		const expectedDivisor = 'next.heroku.app-name.web_*_US.express.*_GET.res.status.*.count';
+		const expectedNumerator = 'next.heroku.app-name.web_*_US.express.*.res.status.{500,503,504}.count';
+		const expectedDivisor = 'next.heroku.app-name.web_*_US.express.*.res.status.*.count';
 
 		subject('app-name');
 		expect(nHealthStub.runCheck).calledWithMatch({
@@ -41,8 +41,8 @@ describe('Default error rate check', () => {
 	it('should compose correct graphite metric without region', () => {
 		delete process.env.REGION;
 
-		const expectedNumerator = 'next.heroku.app-name.web_*.express.*_GET.res.status.500.count';
-		const expectedDivisor = 'next.heroku.app-name.web_*.express.*_GET.res.status.*.count';
+		const expectedNumerator = 'next.heroku.app-name.web_*.express.*.res.status.{500,503,504}.count';
+		const expectedDivisor = 'next.heroku.app-name.web_*.express.*.res.status.*.count';
 
 		subject('app-name');
 


### PR DESCRIPTION
Looking at preflight with these values during a 10 minute period when the alert was going off.

A baseline period of 7 days, a sample period of 10 minutes.

Over 7 days, the baseline error rate for next-preflight was 0.00001.

Over the last 10 minutes, the sample error rate was 0.00000571.

For `graphiteSpike` we take these values and compute the following...

 ```js
const ok = sample / baseline < threshold;
```

https://github.com/Financial-Times/n-health/blob/master/src/checks/graphiteSpike.check.js#L85

With a `threshold` of 0.04, we find that `sample / baseline` is 0.571 and so we're **not** OK.

Using the default `threshold` of 3 in this case I believe will catch major spikes in errors introduced by a release without being too sensitive.

I think the confusion was in thinking that `threshold` is a percentage value.

A dashboard for next-preflight I used to work out what Graphite was returning, http://grafana.ft.com/dashboard/db/next-n-express-error-rate.

