### PR TITLE
Remove the failing default check

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -14,17 +14,7 @@ module.exports = (app, options, meta) => {
 	app.get(/\/__health(?:\.([123]))?$/, (req, res) => {
 		res.set({ 'Cache-Control': 'private, no-cache, max-age=0' });
 		const checks = healthChecks.map(check => check.getStatus());
-		if (checks.length === defaultChecks.length) {
-			checks.push({
-				name: 'App has no additional healthchecks',
-				ok: false,
-				severity: 3,
-				businessImpact: 'If this application encounters any problems, nobody will be alerted and it probably will not get fixed.',
-				technicalSummary: 'This app has no additional healthchecks set up',
-				panicGuide: 'Don\'t Panic',
-				lastUpdated: new Date()
-			});
-		}
+
 		if (req.params[0]) {
 			checks.forEach(check => {
 				if (check.severity <= Number(req.params[0]) && check.ok === false) {


### PR DESCRIPTION
Fixes:

![image](https://user-images.githubusercontent.com/51677/34765406-4c5d17b2-f5e9-11e7-942e-5b6fa80a3458.png)

Is this what we're happy with? There are still two default checks in each app.

Does this stop nudging people to add checks that apps should have?