### PR TITLE
Allow default error rate healthcheck to be configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "next-metrics": "^1.16.1"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^1.19.1",
+    "@financial-times/n-gage": "^1.19.3",
     "body-parser": "^1.15.0",
     "chai": "^3.0.0",
     "coveralls": "^2.11.16",

--- a/src/lib/error-rate-check.js
+++ b/src/lib/error-rate-check.js
@@ -1,20 +1,25 @@
 const nHealth = require('n-health');
 
 const DEFAULT_SEVERITY = 3;
+const DEFAULT_SAMPLE_PERIOD = '10min';
+const DEFAULT_THRESHOLD = 4;
 
 module.exports = (appName, opts) => {
 	opts = opts || {};
 	const severity = opts.severity || DEFAULT_SEVERITY;
+	const threshold = opts.threshold || DEFAULT_THRESHOLD;
+	const samplePeriod = opts.samplePeriod || DEFAULT_SAMPLE_PERIOD;
+
 	let region = process.env.REGION ? '_' + process.env.REGION : '';
 	return nHealth.runCheck({
-		name: `The error rate for ${appName} is greater than 4% of requests`,
-		type: 'graphiteThreshold',
-		metric: `asPercent(summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.{500,503,504}.count), '10min', 'sum', true), summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.*.count), '10min', 'sum', true))`,
-		threshold: 4,
-		samplePeriod: '10min',
-		severity,
-		businessImpact: 'Users may see application error pages.',
-		technicalSummary: `The proportion of error responses for ${appName} is greater than 4% of all responses. This is a default n-express check.`,
-		panicGuide: 'Consult errors in sentry, application logs in splunk and run the application locally to identify errors'
+			name: `The error rate for ${appName} is greater than ${threshold}% of requests`,
+			type: 'graphiteThreshold',
+			metric: `asPercent(summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.{500,503,504}.count), '${samplePeriod}', 'sum', true), summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.*.count), '${samplePeriod}', 'sum', true))`,
+			threshold,
+			samplePeriod,
+			severity,
+			businessImpact: 'Users may see application error pages.',
+			technicalSummary: `The proportion of error responses for ${appName} is greater than 4% of all responses. This is a default n-express check.`,
+			panicGuide: 'Consult errors in sentry, application logs in splunk and run the application locally to identify errors'
 	});
 };

--- a/test/app/error-rate-check.test.js
+++ b/test/app/error-rate-check.test.js
@@ -32,7 +32,9 @@ describe('Default error rate check', () => {
 
 		subject('app-name');
 		expect(nHealthStub.runCheck).calledWithMatch({
-			metric
+			metric,
+			threshold: 4,
+			samplePeriod: '10min'
 		});
 	});
 
@@ -44,6 +46,23 @@ describe('Default error rate check', () => {
 		subject('app-name');
 		expect(nHealthStub.runCheck).calledWithMatch({
 			metric
+		});
+	});
+
+	it('should allow configurable threshold and sample period', () => {
+		delete process.env.REGION;
+
+		const metric = 'asPercent(summarize(sumSeries(next.heroku.app-name.web_*.express.*.res.status.{500,503,504}.count), \'20min\', \'sum\', true), summarize(sumSeries(next.heroku.app-name.web_*.express.*.res.status.*.count), \'20min\', \'sum\', true))';
+
+		subject('app-name', {
+			severity: 3,
+			threshold: 10,
+			samplePeriod: '20min'
+		});
+		expect(nHealthStub.runCheck).calledWithMatch({
+			metric,
+			threshold: 10,
+			samplePeriod: '20min'
 		});
 	});
 


### PR DESCRIPTION
 🐿 v2.7.0

next-retention is an app that gets very little traffic, and their error healthcheck goes off a lot. Adding an option to increase either the sample period or error threshold, so they can make it work for them.