### PR TITLE
First pass at blocking googleweblight crawler

### DIFF
--- a/src/assets/robots.txt
+++ b/src/assets/robots.txt
@@ -1,5 +1,8 @@
 User-agent: Twitterbot
 Disallow:
+
+User-agent: googleweblight
+Disallow:
  
 User-agent: *
 Disallow: /


### PR DESCRIPTION
"First pass" because I'm not entirely convinced this will work. Google's [official recommendation](https://support.google.com/webmasters/answer/6211428?hl=en&ref_topic=2370586) is to send a `Cache-Control: no-transform` header, which would probably have a lot of unintended side effects.

The reason for wanting to disable this is because it has no knowledge of the kind of access a user might have and therefore is hitting the barrier (which is subsequently tanking conversion metrics). Below is a graph representing the volume of page views it's hitting the site with:

[<img width="593" alt="1523882611" src="https://user-images.githubusercontent.com/708296/38809861-e3222a50-417c-11e8-8d28-9dcfc0c49a26.png">]( https://beacon.ft.com/data/query-wizard?query=page%3Aview-%3Ecount()-%3Efilter(device.userAgent~googleweblight)-%3ErelTime(previous_8_weeks)-%3Einterval(w)-%3Etidy() )

🐿 v2.8.0