### PR TITLE
add consent resource local object

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 
 - `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
+- `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`
 - `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)

--- a/main.js
+++ b/main.js
@@ -3,10 +3,17 @@ require('isomorphic-fetch');
 const fs = require('fs');
 const path = require('path');
 const express = require('express');
+
+// flags
 const flags = require('@financial-times/n-flags-client');
+
+// backend authentication
 const backendAuthentication = require('./src/middleware/backend-authentication');
 
-// Logging and monitoring
+// consent
+const consentMiddleware = require('./src/middleware/consent');
+
+// logging and monitoring
 const metrics = require('next-metrics');
 const serviceMetrics = require('./src/lib/service-metrics');
 const raven = require('@financial-times/n-raven');
@@ -29,6 +36,7 @@ const getAppContainer = options => {
 	options = Object.assign({}, {
 		withBackendAuthentication: true,
 		withFlags: false,
+		withConsent: false,
 		withServiceMetrics: true,
 		healthChecks: []
 	}, options || {});
@@ -99,6 +107,11 @@ const getAppContainer = options => {
 	if (options.withFlags) {
 		addInitPromise(flags.init());
 		app.use(flags.middleware);
+	}
+
+	// consent preference flags
+	if (options.withConsent) {
+		app.use(consentMiddleware);
 	}
 
 	// cache-control constants

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@financial-times/n-flags-client": "^9.1.5",
     "@financial-times/n-logger": "^5.6.4",
-    "@financial-times/n-raven": "^3.0.3",
-    "body-parser": "^1.18.2",
+	"@financial-times/n-raven": "^3.0.3",
+	"body-parser": "^1.18.2",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
     "express": "^4.16.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@financial-times/n-gage": "^1.19.7",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
-    "fetch-mock": "^6.3.0",
+    "fetch-mock": "^5.1.2",
     "istanbul": "^0.4.5",
     "mocha": "^3.5.3",
     "npm-prepublish": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@financial-times/n-flags-client": "^9.1.5",
     "@financial-times/n-logger": "^5.6.4",
-	"@financial-times/n-raven": "^3.0.3",
-	
+    "@financial-times/n-raven": "^3.0.3",
     "body-parser": "^1.18.2",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
@@ -29,7 +28,7 @@
     "coveralls": "^3.0.0",
     "fetch-mock": "^6.3.0",
     "istanbul": "^0.4.5",
-    "mocha": "^5.1.1",
+    "mocha": "^3.5.3",
     "npm-prepublish": "^1.2.3",
     "proxyquire": "^2.0.1",
     "shellpromise": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -10,33 +10,32 @@
     "prepush": "make verify -j3"
   },
   "dependencies": {
-    "@financial-times/n-flags-client": "^9.0.0",
-    "@financial-times/n-logger": "^5.6.0",
-    "@financial-times/n-raven": "^3.0.0",
-    "debounce": "^1.0.0",
+    "@financial-times/n-flags-client": "^9.1.5",
+    "@financial-times/n-logger": "^5.6.4",
+	"@financial-times/n-raven": "^3.0.3",
+	
+    "body-parser": "^1.18.2",
+    "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
-    "express": "^4.14.0",
-    "ip": "^1.1.4",
-    "isomorphic-fetch": "^2.0.0",
-    "n-health": "^2.0.18",
-    "next-metrics": "^1.16.1"
+    "express": "^4.16.3",
+    "ip": "^1.1.5",
+    "isomorphic-fetch": "^2.2.1",
+    "n-health": "^2.3.2",
+    "next-metrics": "^1.48.36"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.7",
-    "body-parser": "^1.15.0",
-    "chai": "^3.0.0",
-    "coveralls": "^2.11.16",
-    "eslint": "^2.5.3",
-    "fetch-mock": "^5.1.2",
+    "chai": "^4.1.2",
+    "coveralls": "^3.0.0",
+    "fetch-mock": "^6.3.0",
     "istanbul": "^0.4.5",
-    "lintspaces-cli": "^0.1.1",
-    "mocha": "^3.2.0",
-    "npm-prepublish": "^1.2.1",
-    "proxyquire": "^1.7.10",
+    "mocha": "^5.1.1",
+    "npm-prepublish": "^1.2.3",
+    "proxyquire": "^2.0.1",
     "shellpromise": "^1.4.0",
-    "sinon": "^1.17.4",
-    "sinon-chai": "^2.10.0",
-    "supertest": "^1.0.0"
+    "sinon": "^4.5.0",
+    "sinon-chai": "^3.0.0",
+    "supertest": "^3.0.0"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/src/middleware/consent.js
+++ b/src/middleware/consent.js
@@ -1,0 +1,21 @@
+module.exports = (req, res, next) => {
+	res.locals = res.locals || {};
+	res.locals.consent = res.locals.consent || {};
+
+	const consent = req.get('ft-consent');
+	if(consent && consent !== '-') {
+		// parse consent preferences from preflight header:
+		// ft-consent=marketingByemail:on,recommendedcontentOnsite:off
+		// becomes
+		// res.locals.consent = {
+		// 	marketingByemail: true,
+		// 	recommendedcontentOnsite: false
+		// }
+		const consentPreferences = consent.split(',');
+		consentPreferences.array.forEach(consentFlag => {
+			const [ key, state ] = consentFlag.split(':');
+			res.locals.consent[key] = state === 'on';
+		});
+	}
+	next();
+};

--- a/src/middleware/consent.js
+++ b/src/middleware/consent.js
@@ -12,9 +12,11 @@ module.exports = (req, res, next) => {
 		// 	recommendedcontentOnsite: false
 		// }
 		const consentPreferences = consent.split(',');
-		consentPreferences.array.forEach(consentFlag => {
+		consentPreferences.forEach(consentFlag => {
 			const [ key, state ] = consentFlag.split(':');
-			res.locals.consent[key] = state === 'on';
+			if(key && state) {
+				res.locals.consent[key] = state === 'on';
+			}
 		});
 	}
 	next();

--- a/src/middleware/log-vary.js
+++ b/src/middleware/log-vary.js
@@ -19,7 +19,7 @@ module.exports = (req, res, next) => {
 
 			vary.map(header => {
 				toLog[header] = req.get(header);
-			})
+			});
 			nLogger.warn(toLog);
 		});
 	}

--- a/test/middleware/consent.test.js
+++ b/test/middleware/consent.test.js
@@ -1,0 +1,73 @@
+/*global describe, it, beforeEach*/
+const request = require('supertest');
+const nextExpress = require('../../main');
+const expect = require('chai').expect;
+
+describe('Consent middleware', function () {
+	let app;
+	let locals;
+
+	before(function () {
+		app = nextExpress({
+			systemCode: 'consent',
+			withConsent: true
+		});
+		app.get('/', function (req, res) {
+			locals = res.locals;
+			res.sendStatus(200).end();
+		});
+	});
+
+	it('Should set the res.locals.consent property', function (done) {
+		request(app)
+			.get('/')
+			.expect(function () {
+				expect(locals).to.have.property('consent');
+			})
+			.end(done);
+	});
+
+	it('Should handle the FT-Consent="-" header', function (done) {
+		request(app)
+			.get('/')
+			.set('FT-Consent', '-')
+			.expect(function () {
+				expect(locals.consent).to.be.empty.and.an('object');
+			})
+			.end(done);
+	});
+
+	context('Should set the res.locals.consent property based on the FT-Consent header', () => {
+		[ 
+			{
+				header: 'marketingByemail:on,recommendedcontentOnsite:off',
+				expectedObject: {
+					marketingByemail: true,
+					recommendedcontentOnsite: false
+				}
+			},
+			{
+				header: 'marketingByemail:notOn,not-a-valid-consent',
+				expectedObject: {
+					marketingByemail: false
+				}
+			},
+			{
+				header: ':',
+				expectedObject: {}
+			}
+		].forEach(({ header, expectedObject }) => {
+
+			it(`ft-consent="${header}`, function (done) {
+				request(app)
+					.get('/')
+					.set('FT-Consent', header)
+					.expect(function () {
+						expect(locals.consent).to.deep.equal(expectedObject);
+					})
+					.end(done);
+			});
+
+		});
+	});
+});

--- a/test/middleware/consent.test.js
+++ b/test/middleware/consent.test.js
@@ -38,7 +38,7 @@ describe('Consent middleware', function () {
 	});
 
 	context('Should set the res.locals.consent property based on the FT-Consent header', () => {
-		[ 
+		[
 			{
 				header: 'marketingByemail:on,recommendedcontentOnsite:off',
 				expectedObject: {

--- a/test/middleware/consent.test.js
+++ b/test/middleware/consent.test.js
@@ -1,4 +1,3 @@
-/*global describe, it, beforeEach*/
 const request = require('supertest');
 const nextExpress = require('../../main');
 const expect = require('chai').expect;


### PR DESCRIPTION
**[GDPR]**

**Enables `withConsent` app option:**
If the `FT-Consent` header is present, parse its content into `res.locals.consent`:
```js
ft-consent=marketingByemail:on,recommendedcontentOnsite:off`
```
--->
```js
res.locals.consent = {
 	marketingByemail: true,
 	recommendedcontentOnsite: false
}
```

See https://github.com/Financial-Times/next-preflight/pull/304 for background on the `FT-Consent` header.
