### PR TITLE
No unregistered service reset

### DIFF
--- a/src/lib/service-metrics.js
+++ b/src/lib/service-metrics.js
@@ -7,7 +7,6 @@ module.exports = {
 		unRegisteredServicesHealthCheck.updateCheck(unregisteredServices);
 		setInterval(() => {
 			unRegisteredServicesHealthCheck.updateCheck(unregisteredServices);
-			unregisteredServices = {};
 		}, 1 * 60 * 1000);
 
 		metrics.fetch.instrument({


### PR DESCRIPTION
This check is _really_ flappy.

My thinking behind not resetting is that we don't need to. If we've fixed this check, then that'll be via a deploy of the application that reboots everything anyway.

The issue with resetting is in a given minute we won't always call a service, this is what leads this to be a flappy health check.

The alternative might be to increase the interval to 5 minutes, but there's still a chance it'd be flappy.