### PR TITLE
use express.json() rather than bodyparser

### DIFF
--- a/main.js
+++ b/main.js
@@ -131,6 +131,7 @@ const getAppContainer = options => {
 module.exports = options => getAppContainer(options).app;
 
 // expose internals the app may want access to
+module.exports.json = express.json;
 module.exports.Router = express.Router;
 module.exports.static = express.static;
 module.exports.metrics = metrics;

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@financial-times/n-flags-client": "^9.1.5",
     "@financial-times/n-logger": "^5.6.4",
-	"@financial-times/n-raven": "^3.0.3",
-	"body-parser": "^1.18.2",
+    "@financial-times/n-raven": "^3.0.3",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
     "express": "^4.16.3",
@@ -23,7 +22,7 @@
     "next-metrics": "^1.49.5"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^1.19.7",
+    "@financial-times/n-gage": "^1.19.14",
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "fetch-mock": "^5.1.2",

--- a/test/fixtures/app/error-rate-check-disabled.js
+++ b/test/fixtures/app/error-rate-check-disabled.js
@@ -103,7 +103,7 @@ app.get('/cache', (req, res) => {
 	res.sendStatus(200);
 });
 
-app.post('/cache', require('body-parser').json(), (req, res) => {
+app.post('/cache', express.json(), (req, res) => {
 	res.cache(req.body[0], req.body[1]);
 	res.sendStatus(200);
 });

--- a/test/fixtures/app/main.js
+++ b/test/fixtures/app/main.js
@@ -99,7 +99,7 @@ app.get('/cache', (req, res) => {
 	res.sendStatus(200);
 });
 
-app.post('/cache', require('body-parser').json(), (req, res) => {
+app.post('/cache', express.json(), (req, res) => {
 	res.cache(req.body[0], req.body[1]);
 	res.sendStatus(200);
 });


### PR DESCRIPTION
- we use express  4.16.3
- as of 4.16.0 , express has a json middleware built in
- see: https://expressjs.com/en/api.html
- fully compatible with body-parser as it's based on it
- exposed the json middleware so that you can do something like:
```
const express = require('@financial-times/n-express');
app.use(express.json());
```