### PR TITLE
Upgrade next-metrics to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^2.3.2",
-    "next-metrics": "^1.49.18"
+    "next-metrics": "^2.0.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",


### PR DESCRIPTION
https://github.com/Financial-Times/next-metrics/releases/tag/v2.0.0

 🐿 v2.10.2