### PR TITLE
This bumps next metrics to 2.1.0. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^2.3.2",
-    "next-metrics": "^1.49.18"
+    "next-metrics": "^2.1.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",


### PR DESCRIPTION
This bumps next metrics to 2.1.0.  This version of next metrics includes a breaking change so we should probably release this as a major release.

 🐿 v2.10.2