### PR TITLE
Upgrade next-metrics to v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^2.3.2",
-    "next-metrics": "^1.49.18"
+    "next-metrics": "^2.2.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",

--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -1,6 +1,7 @@
 const errorRateCheck = require('./error-rate-check');
 const awsKeysHealthCheck = require('./aws-keys-healthcheck');
 const unRegisteredServicesHealthCheck = require('./unregistered-services-healthCheck');
+const metricsHealthCheck = require('./metrics-healthcheck');
 
 module.exports = (app, options, meta) => {
 	const defaultAppName = `Next FT.com ${meta.name} in ${process.env.REGION || 'unknown region'}`;
@@ -9,7 +10,8 @@ module.exports = (app, options, meta) => {
 	const defaultChecks = [
 		errorRateCheck(meta.name, options.errorRateHealthcheck),
 		unRegisteredServicesHealthCheck.setAppName(meta.name),
-		...awsKeysHealthCheck.checks
+		...awsKeysHealthCheck.checks,
+		metricsHealthCheck(meta.name),
 	];
 
 	const healthChecks = options.healthChecks.concat(defaultChecks);

--- a/src/lib/metrics-healthcheck.js
+++ b/src/lib/metrics-healthcheck.js
@@ -10,7 +10,7 @@ module.exports = (appName) => {
 				checkOutput: metrics.hasValidConfiguration ? `next-metrics configuration is valid for ${appName}` : `next-metrics configuration is NOT valid for ${appName}`,
 				lastUpdated: new Date(),
 				severity: 2,
-				panicGuide: `Check that ${appName} is configured as described in the next-metrics README: https://github.com/Financial-Times/next-metrics`,
+				panicGuide: `Check ${appName} application logs and that ${appName} is configured as described in the next-metrics README: https://github.com/Financial-Times/next-metrics`,
 				businessImpact: `Severely reduced visibility of any ${appName} production issues`,
 				technicalSummary: `The configuration for ${appName} needs to be fixed so that next-metrics can send metrics`,
 			};

--- a/src/lib/metrics-healthcheck.js
+++ b/src/lib/metrics-healthcheck.js
@@ -5,9 +5,9 @@ module.exports = (appName) => {
 	return {
 		getStatus: () => {
 			return {
-				name: `Metrics configured for ${appName}`,
+				name: `Metrics: next-metrics configuration valid for ${appName}`,
 				ok: metrics.hasValidConfiguration,
-				checkOutput: metrics.hasValidConfiguration ? `next-metrics has been configured for ${appName}` : `next-metrics has NOT been configured for ${appName}`,
+				checkOutput: metrics.hasValidConfiguration ? `next-metrics configuration is valid for ${appName}` : `next-metrics configuration is NOT valid for ${appName}`,
 				lastUpdated: new Date(),
 				severity: 2,
 				panicGuide: `Check that ${appName} is configured as described in the next-metrics README: https://github.com/Financial-Times/next-metrics`,

--- a/src/lib/metrics-healthcheck.js
+++ b/src/lib/metrics-healthcheck.js
@@ -1,0 +1,20 @@
+const metrics = require('next-metrics');
+
+module.exports = (appName) => {
+
+	return {
+		getStatus: () => {
+			return {
+				name: `Metrics configured for ${appName}`,
+				ok: metrics.hasValidConfiguration,
+				checkOutput: metrics.hasValidConfiguration ? `next-metrics has been configured for ${appName}` : `next-metrics has NOT been configured for ${appName}`,
+				lastUpdated: new Date(),
+				severity: 2,
+				panicGuide: `Check that ${appName} is configured as described in the next-metrics README: https://github.com/Financial-Times/next-metrics`,
+				businessImpact: `Severely reduced visibility of any ${appName} production issues`,
+				technicalSummary: `The configuration for ${appName} needs to be fixed so that next-metrics can send metrics`,
+			};
+		}
+	};
+
+};


### PR DESCRIPTION
Fixes #522.

 🐿 v2.10.2

----

**Test cases**

Configuration options allowed by `next-metrics`: https://github.com/Financial-Times/next-metrics#configuration

Valid configuration with environment variables:

- `NODE_ENV=production` ; `HOSTEDGRAPHITE_APIKEY=12345`
- `NODE_ENV=production` ; `FT_GRAPHITE_APIKEY=12345`
- `NODE_ENV=production` ; `HOSTEDGRAPHITE_APIKEY=false`
- `NODE_ENV=production` ; `FT_GRAPHITE_APIKEY=false`
- `NODE_ENV=development`
- `NODE_ENV=development` ; `HOSTEDGRAPHITE_APIKEY=12345`
- `NODE_ENV=development` ; `FT_GRAPHITE_APIKEY=12345`

Invalid configuration with environment variables:

- `NODE_ENV=production`
- `NODE_ENV=production` ; `HOSTEDGRAPHITE_APIKEY=`
- `NODE_ENV=production` ; `FT_GRAPHITE_APIKEY=`
- `NODE_ENV=production` ; `HOSTEDGRAPHITE_APIKEY=` ; `FT_GRAPHITE_APIKEY=`