### PR TITLE
Upgrade to next-metrics 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^2.3.2",
-    "next-metrics": "3.0.0-beta.2"
+    "next-metrics": "^3.0.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",


### PR DESCRIPTION
Part of the graphite v2 migration.

https://github.com/Financial-Times/next/projects/1#card-12751210