### PR TITLE
update n-logger to v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@financial-times/n-flags-client": "^9.1.5",
-    "@financial-times/n-logger": "^5.6.4",
+    "@financial-times/n-logger": "^6.0.0",
     "@financial-times/n-raven": "^3.0.3",
     "aws-sdk": "^2.266.1",
     "debounce": "^1.1.0",


### PR DESCRIPTION
Upgrades n-logger to major release v6.0.0 which removes the Splunk forwarder transport and instead relies on the Http Event Collector only. 