### PR TITLE
Upgrade n-health

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
-    "n-health": "^2.3.2",
+    "n-health": "^3.0.0",
     "next-metrics": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Points Graphite health checks at the new address, `graphitev2-api.ft.com`.

https://github.com/Financial-Times/next/issues/170