### PR TITLE
Revert "Upgrade n-health"

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
-    "n-health": "^3.0.0",
+    "n-health": "^2.3.2",
     "next-metrics": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts Financial-Times/n-express#532.

Relates to https://github.com/Financial-Times/next/issues/170.

Unfortunately we're seeing issues with the new Graphite system after preflight moved over and we started reading from `graphitev2-api.ft.com`.