### PR TITLE
Re-release n-health v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
-    "n-health": "^2.3.2",
+    "n-health": "^3.0.0",
     "next-metrics": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts Financial-Times/n-express#533.

This upgrades n-health to v3.0.0, which will point at the new Graphite system.