### PR TITLE
Update `next-metrics` to v3.1.0-beta.2

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,7 +81,6 @@ const getAppContainer = options => {
 
 	// metrics should be one of the first things as needs to be applied before any other middleware executes
 	metrics.init({
-		app: process.env.FT_APP_VARIANT ? `${meta.name}_${process.env.FT_APP_VARIANT}` : meta.name,
 		flushEvery: 40000
 	});
 	app.use((req, res, next) => {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.0.7"
+    "next-metrics": "v3.1.0-beta.2"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",

--- a/test/app/app.test.js
+++ b/test/app/app.test.js
@@ -91,7 +91,7 @@ describe('simple app', function () {
 		it('should initialise metrics', function () {
 			sinon.stub(metrics, 'init');
 			getApp();
-			expect(metrics.init.calledWith({app: 'demo-app', flushEvery: 40000 })).to.be.true;
+			expect(metrics.init.calledWith({flushEvery: 40000 })).to.be.true;
 			metrics.init.restore();
 		});
 
@@ -99,7 +99,7 @@ describe('simple app', function () {
 			sinon.stub(metrics, 'init');
 			process.env.FT_APP_VARIANT = 'testing';
 			getApp();
-			expect(metrics.init.calledWith({app: 'demo-app_testing', flushEvery: 40000 })).to.be.true;
+			expect(metrics.init.calledWith({flushEvery: 40000 })).to.be.true;
 			metrics.init.restore();
 			delete process.env.FT_APP_VARIANT;
 		});


### PR DESCRIPTION
- Pull in `next-metrics` beta release so we can test it in an `n-express` beta release
- Remove deprecated `app` option from call to `Metrics#init`

Resolves #537.

 🐿 v2.11.0