### PR TITLE
Update to `next-metrics` v3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "v3.1.0-beta.2"
+    "next-metrics": "3.1.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",


### PR DESCRIPTION
Description: Remove legacy FT Graphite support
Release notes: https://github.com/Financial-Times/next-metrics/releases/tag/v3.1.0