### PR TITLE
Stop pinning the version of next-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "3.1.3"
+    "next-metrics": "^3.1.3"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^1.19.14",


### PR DESCRIPTION
Now the graphite migration is over, we should be good to not pin this dependency any more.

Relates to https://github.com/Financial-Times/next/issues/258.