### PR TITLE
Updated automated n-express error rate healthchecks to use app.system…

### DIFF
--- a/src/lib/guess-app-details.js
+++ b/src/lib/guess-app-details.js
@@ -19,6 +19,7 @@ module.exports = options => {
 	if (!name) throw new Error('Please specify an application name');
 
 	name = name && normalizeName(name);
+	let systemCode = options.systemCode ? options.systemCode : options.name;
 
-	return {name, description, directory};
+	return {name, description, directory, systemCode};
 };

--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -6,7 +6,7 @@ module.exports = (app, options, meta) => {
 	const defaultAppName = `Next FT.com ${meta.name} in ${process.env.REGION || 'unknown region'}`;
 
 	const defaultChecks = [
-		errorRateCheck(meta.name, options.errorRateHealthcheck),
+		errorRateCheck(meta.systemCode, options.errorRateHealthcheck),
 		unRegisteredServicesHealthCheck.setAppName(meta.name),
 		metricsHealthCheck(meta.name),
 	];


### PR DESCRIPTION
Currently n-express allows us to enter app.name and app.systemCode in its settings. We, in next-subscribe use both properties, and they are different. 
n-express also have few automated [health checks](https://github.com/Financial-Times/n-express/blob/e9b2962dc571a62341ee41092ec88faceff1639f/src/lib/error-rate-check.js#L17) which use app.name to generate Grafana path. 
This PR replaces usage of app.name with app.systemCode in error rate healthcheck




 🐿 v2.12.3