### PR TITLE
Bump next-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.3"
+    "next-metrics": "^3.1.9"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.6.0",


### PR DESCRIPTION
To stop Heroku using cached 3.1.3