### PR TITLE
add support for separate graphiteName field

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Passed in to `require('@financial-times/n-express')(options)`, these (Booleans d
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 - `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.
+- `graphiteName` String - the app's name in Graphite, for formatting queries. Defaults to the `systemCode`.
 
 ## Static properties and methods
 - `Router` - `express.Router`

--- a/src/lib/error-rate-check.js
+++ b/src/lib/error-rate-check.js
@@ -11,15 +11,16 @@ module.exports = (appName, opts) => {
 	const samplePeriod = opts.samplePeriod || DEFAULT_SAMPLE_PERIOD;
 
 	let region = process.env.REGION ? '_' + process.env.REGION : '';
+
 	return nHealth.runCheck({
-			name: `Error rate: greater than ${threshold}% of requests for ${appName}`,
-			type: 'graphiteThreshold',
-			metric: `asPercent(summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.{500,503,504}.count), '${samplePeriod}', 'sum', true), summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.*.count), '${samplePeriod}', 'sum', true))`,
-			threshold,
-			samplePeriod,
-			severity,
-			businessImpact: 'Users may see application error pages.',
-			technicalSummary: `The proportion of error responses for ${appName} is greater than 4% of all responses. This is a default n-express check.`,
-			panicGuide: 'Consult errors in sentry, application logs in splunk and run the application locally to identify errors'
+		name: `Error rate: greater than ${threshold}% of requests for ${appName}`,
+		type: 'graphiteThreshold',
+		metric: `asPercent(summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.{500,503,504}.count), '${samplePeriod}', 'sum', true), summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.*.count), '${samplePeriod}', 'sum', true))`,
+		threshold,
+		samplePeriod,
+		severity,
+		businessImpact: 'Users may see application error pages.',
+		technicalSummary: `The proportion of error responses for ${appName} is greater than 4% of all responses. This is a default n-express check.`,
+		panicGuide: 'Consult errors in sentry, application logs in splunk and run the application locally to identify errors'
 	});
 };

--- a/src/lib/guess-app-details.js
+++ b/src/lib/guess-app-details.js
@@ -1,17 +1,16 @@
 const normalizeName = require('./normalize-name');
 
 module.exports = options => {
-	let packageJson = {};
 	let name = options.name;
 	let description = '';
 	let directory = options.directory || process.cwd();
 
 	if (!name) {
 		try {
-			packageJson = require(directory + '/package.json');
+			const packageJson = require(directory + '/package.json');
 			name = packageJson.name;
 			description = packageJson.description || '';
-		} catch(e) {
+		} catch (e) {
 			// Safely ignorable error
 		}
 	}
@@ -19,7 +18,8 @@ module.exports = options => {
 	if (!name) throw new Error('Please specify an application name');
 
 	name = name && normalizeName(name);
-	let systemCode = options.systemCode ? options.systemCode : options.name;
+	const systemCode = options.systemCode || options.name;
+	const graphiteName = options.graphiteName || systemCode;
 
-	return {name, description, directory, systemCode};
+	return { name, description, directory, systemCode, graphiteName };
 };

--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -6,7 +6,7 @@ module.exports = (app, options, meta) => {
 	const defaultAppName = `Next FT.com ${meta.name} in ${process.env.REGION || 'unknown region'}`;
 
 	const defaultChecks = [
-		errorRateCheck(meta.systemCode, options.errorRateHealthcheck),
+		errorRateCheck(meta.graphiteName, options.errorRateHealthcheck),
 		unRegisteredServicesHealthCheck.setAppName(meta.name),
 		metricsHealthCheck(meta.name),
 	];


### PR DESCRIPTION
in case it's different to the systemCode (which it usually is). see #563. doesn't fix that issue on its own, but will once all 62 apps have a correct `graphiteCode`