### PR TITLE
Bump next-metrics version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.18"
+    "next-metrics": "^3.1.19"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.6.0",


### PR DESCRIPTION
I want to make sure this component picks up latest changes to `next-metrics`. The change fixes failing health checks for `next-syn-list`.