### PR TITLE
Bump next-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.19"
+    "next-metrics": "^3.1.24"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.6.0",


### PR DESCRIPTION
This should fix the failing healthcheck for `next-comments-api` by picking up the changes I made to the service list in `next-metrics`.