### PR TITLE
Bump n-metrics version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.24"
+    "next-metrics": "^3.1.25"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
Bump n-metrics to v3.1.25 to silence alerts about missing metrics for 8 apps.

https://financialtimes.atlassian.net/jira/software/projects/NOPSCOPS/boards/952?selectedIssue=NOPSCOPS-130