### PR TITLE
Bump express for compatibility with node v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@financial-times/n-raven": "^3.0.3",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
-    "express": "^4.16.3",
+    "express": "^4.17.0",
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",


### PR DESCRIPTION
express is only fully compatible with node 12 as of 4.17.0: https://expressjs.com/en/changelog/4x.html