### PR TITLE
Bump next-metrics to 3.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.26"
+    "next-metrics": "^3.1.28"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
This will silence alerts related to the calls to the new bit.ly API endpoint and salesforce not being registered.

https://financialtimes.atlassian.net/jira/software/projects/NOPSCOPS/boards/952?selectedIssue=NOPSCOPS-130