### PR TITLE
Bump next-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.26"
+    "next-metrics": "^3.1.28"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
This release registers two Salesforce APIs used by next-subscribe.