### PR TITLE
Add id to default checks

### DIFF
--- a/src/lib/error-rate-check.js
+++ b/src/lib/error-rate-check.js
@@ -13,6 +13,7 @@ module.exports = (appName, opts) => {
 	let region = process.env.REGION ? '_' + process.env.REGION : '';
 
 	return nHealth.runCheck({
+		id: 'error-rate',
 		name: `Error rate: greater than ${threshold}% of requests for ${appName}`,
 		type: 'graphiteThreshold',
 		metric: `asPercent(summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.{500,503,504}.count), '${samplePeriod}', 'sum', true), summarize(sumSeries(next.heroku.${appName}.web_*${region}.express.*.res.status.*.count), '${samplePeriod}', 'sum', true))`,

--- a/src/lib/metrics-healthcheck.js
+++ b/src/lib/metrics-healthcheck.js
@@ -5,6 +5,7 @@ module.exports = (appName) => {
 	return {
 		getStatus: () => {
 			return {
+				id: 'next-metrics-configuration-valid',
 				name: `Metrics: next-metrics configuration valid for ${appName}`,
 				ok: metrics.hasValidConfiguration,
 				checkOutput: metrics.hasValidConfiguration ? `next-metrics configuration is valid for ${appName}` : `next-metrics configuration is NOT valid for ${appName}`,

--- a/src/lib/unregistered-services-healthCheck.js
+++ b/src/lib/unregistered-services-healthCheck.js
@@ -8,6 +8,7 @@ module.exports = {
 		return {
 			getStatus: () => {
 				return {
+					id: 'all-services-registered',
 					name: `Metrics: All services for ${appName} registered in next-metrics`,
 					ok: lastCheckOk,
 					checkOutput: lastCheckOutput,


### PR DESCRIPTION
The healthcheck standards specify that each individual check requires an id. This adds an id to the default checks.

[Healthcheck standards](https://docs.google.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit#)