### PR TITLE
Bump next-metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^3.0.0",
-    "next-metrics": "^3.1.33"
+    "next-metrics": "^3.1.34"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
Bumps next-metrics to [v3.1.34](https://github.com/Financial-Times/next-metrics/releases/tag/v3.1.34)