### PR TITLE
Add withAb option to n-express so that res.locals.flags can optionally be set to include Ammit flag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 
 - `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
+- `withAb` - if `withFlags` is true, `withAb` will set `res.locals.flags` values based on the variant/control to which a user is assigned for flags with an ammitSetup. Without this all Ammit flags will be set to false in `res.locals.flags`.
 - `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`
 - `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model

--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@ const getAppContainer = options => {
 	options = Object.assign({}, {
 		withBackendAuthentication: true,
 		withFlags: false,
+		withAb: false,
 		withConsent: false,
 		withServiceMetrics: true,
 		healthChecks: []
@@ -104,7 +105,7 @@ const getAppContainer = options => {
 
 	// feature flags
 	if (options.withFlags) {
-		addInitPromise(flags.init());
+		addInitPromise(flags.init({withAb: options.withAb}));
 		app.use(flags.middleware);
 	}
 


### PR DESCRIPTION
n-flags-client has an option `withAb` which allows the values of flags to be set to their Ammit variant value (if the user is in a variant). This PR makes use of that and adds an optional `withAb` value to n-express so that apps can access these values if required. As things stand, in an app that's using n-express, an example flag `testAmmitFlag` with a specified `ammitSetup` and a `state` of `false` (flags with `ammitSetup` always have a `state` of `false` - see "Limitations and notes" here: https://github.com/Financial-Times/next-ammit-api#setup-details) we would see that `res.locals.flags.testAmmitFlag` would always equal `false`, because the state is false. If we were to release this PR and initialise n-express with `withAb` set to `true`, we would see that `res.locals.flags.testAmmitFlag` would switch between different possible variant values and false. This behaviour is desired in next-subscribe.