### PR TITLE
Improve warning message and readme for backend authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 
 ### Optional
 
-- `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality
+- `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality. Backend authentication is required for applications serving traffic that should only come via the Fastly -> Preflight -> Router request routing. An example of why is the Next Article application, if this didn't have backend authentication enabled you would be able to view articles via the heroku application url as it wouldn't be protected by barriers which are handled within Fastly and Preflight.
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
 - `withAb` - if `withFlags` is true, `withAb` will set `res.locals.flags` values based on the variant/control to which a user is assigned for flags with an ammitSetup. Without this all Ammit flags will be set to false in `res.locals.flags`.
 - `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`

--- a/src/middleware/backend-authentication.js
+++ b/src/middleware/backend-authentication.js
@@ -12,10 +12,16 @@ module.exports = (app, appName) => {
 	}
 
 	if (!backendKeys.length) {
+		const missingEnvVarsMessage = [
+			'Backend authentication is disabled due to missing environment variables -',
+			'If backend authentication isn\'t required then disable this middleware by setting the n-express \'withBackendAuthentication\' option to false.',
+			'To enable backend authentication add the missing environment variables.',
+			'For more info on backend authentication see https://github.com/Financial-Times/n-express#optional',
+		];
 
 		nLogger.warn({
-			event: 'BACKEND_AUTHENTICATION_DISABLED',
-			message: 'Backend authentication is disabled, this app is exposed directly to the internet. To enable, add keys in config-vars'
+			event: 'BACKEND_AUTHENTICATION_MISSING_ENV_VARS',
+			message: missingEnvVarsMessage.join(' ')
 		});
 
 		return;


### PR DESCRIPTION
During a recent incident we found that the warning message in this situation could be misleading and make you think backend authentication is always required and it's a scary thing when it is not.

I am not sure if this updates are perfect but hopefully they go some way towards making it better without making it to confusing. 

I am very happy if anyone has any suggestions on ways to improve the wording I have chosen here.

Original incident -> https://github.com/Financial-Times/incident-reports/issues/347