### PR TITLE
Upgrade n-health ^3.0.0 -> ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "ip": "^1.1.5",
     "isomorphic-fetch": "^2.2.1",
-    "n-health": "^3.0.0",
+    "n-health": "^5.0.0",
     "next-metrics": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades `n-health` to v5 so that apps consuming `n-express` can start migrating their Pingdom checks as per the `n-health` [v5 release notes](https://github.com/Financial-Times/n-health/releases/tag/v5.0.0).

This will require a major release for the same reason that the changes in `n-health` were a major release.