### PR TITLE
Upgrade next-metrics to v5.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^5.0.0",
-    "next-metrics": "^5.0.7"
+    "next-metrics": "^5.0.9"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
To include updates to our little service catalogue in next-metrics that maps URLs to names. You know the drill.