### PR TITLE
Update next-metrics to v.5.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^5.0.0",
-    "next-metrics": "^5.0.17"
+    "next-metrics": "^5.0.18"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
Incorporate this release https://github.com/Financial-Times/next-metrics/releases/tag/v5.0.18