### PR TITLE
Bump next-metrics to v5.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^5.0.0",
-    "next-metrics": "^5.0.18"
+    "next-metrics": "^5.0.20"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
to register all services.