### PR TITLE
Bump n-health to v5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",
-    "n-health": "^5.0.0",
+    "n-health": "^5.0.1",
     "next-metrics": "^5.0.20"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump n-health to [v5.0.1](https://github.com/Financial-Times/n-health/releases/tag/v5.0.1)