### PR TITLE
Bump next metrics to 5.0.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^2.2.1",
     "n-health": "^5.0.0",
-    "next-metrics": "^5.0.22"
+    "next-metrics": "^5.0.23"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^3.12.0",


### PR DESCRIPTION
Bump next metrics to 5.0.23 which fixes the capi-v2-concepts regex for service matching