### PR TITLE
[NOPS-997] Bump next-metrics to at least 5.0.29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6676,9 +6676,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.0.26",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.26.tgz",
-      "integrity": "sha512-N8LM4w0m4ErqO5YK2ilRuwvQWwZLE4sFXnqaoq8E+y11Uu2xuLu8kqTdoQXK0VCMS+pByPDknjJJBt9gbg3yrw==",
+      "version": "5.0.29",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.29.tgz",
+      "integrity": "sha512-CFy5EkmYBRGC1V49MqmrPtuuQCsdmXolIG2W5T/h4rqThkwPsg2kPc1w060xvpNyKhngL/CtSd127BTDCSSQ8A==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.1",
-    "next-metrics": "^5.0.26"
+    "next-metrics": "^5.0.29"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
To fix a failing healthcheck in preflight and stream-page