### PR TITLE
Bump next-metrics to 5.0.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.1",
-    "next-metrics": "^5.0.29"
+    "next-metrics": "^5.0.30"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
This includes the bump to npm 7 and adds the invoice-api-test to services.

https://financialtimes.atlassian.net/browse/ACC-1203