### PR TITLE
Don't force dependents to be use npm 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-express",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-flags-client": "^10.0.0",
         "@financial-times/n-logger": "^8.0.0",
@@ -17,7 +16,7 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.1",
-        "next-metrics": "^5.0.25"
+        "next-metrics": "^5.0.30"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8119,16 +8118,17 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "5.0.25",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.25.tgz",
-      "integrity": "sha512-jsXSjtq8/PRfel4EGP9Dttbto7yiSS+9vwTjgoTlTOmyp0S6k6YT3h5S6z9CjGjW5Bf9vKADD89MMQf0kMQvtQ==",
+      "version": "5.0.30",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.30.tgz",
+      "integrity": "sha512-xbVFw4xYXN2evSvPr14PWQGJ2emUvmv5D4Fb2UlQje4kJCRAJ0q0DKjbRuFtN+rW9SJaa49wCCXbFjvlUu0fdw==",
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",
         "metrics": "^0.1.8"
       },
       "engines": {
-        "node": "12.x"
+        "node": "12.x",
+        "npm": "7.x"
       }
     },
     "node_modules/next-metrics/node_modules/@financial-times/n-logger": {
@@ -20218,9 +20218,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.0.29",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.29.tgz",
-      "integrity": "sha512-CFy5EkmYBRGC1V49MqmrPtuuQCsdmXolIG2W5T/h4rqThkwPsg2kPc1w060xvpNyKhngL/CtSd127BTDCSSQ8A==",
+      "version": "5.0.30",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.30.tgz",
+      "integrity": "sha512-xbVFw4xYXN2evSvPr14PWQGJ2emUvmv5D4Fb2UlQje4kJCRAJ0q0DKjbRuFtN+rW9SJaa49wCCXbFjvlUu0fdw==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "make test",
     "test:types": "tsc",
     "commit": "commit-wizard",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
     "@financial-times/n-flags-client": "^10.0.0",
@@ -58,7 +57,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
-      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-commit": "node_modules/.bin/secret-squirrel && npm_config_yes=true npx check-engine",
       "pre-push": "make verify -j3"
     }
   }


### PR DESCRIPTION
The `check-engine` script we were using to enforce npm 7 usage when developing locally was also being run when the package was installed by other consumers, causing the installation to fail if they were using an npm version other than 7. This is an unnecessarily restrictive requirement which would mean the npm 7 update was a breaking change -- not our intention.

Instead, run the version check in a git hook so that it is only enforced during local development, as was originally intended. Unfortunately, the version of husky we are using breaks the `PATH` in a way that causes a false negative when the default version of npm installed by Volta is not npm 7, but we need to get this unblocked now so we don't need to make a major release. We can make another patch fixing this bug later.