### PR TITLE
Bump up next-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.1",
-        "next-metrics": "^5.0.30"
+        "next-metrics": "^5.0.31"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8118,9 +8118,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.30.tgz",
-      "integrity": "sha512-xbVFw4xYXN2evSvPr14PWQGJ2emUvmv5D4Fb2UlQje4kJCRAJ0q0DKjbRuFtN+rW9SJaa49wCCXbFjvlUu0fdw==",
+      "version": "5.0.31",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.31.tgz",
+      "integrity": "sha512-U0KfwWJkUkfu62HxhYmj6GXdMMb7Y5LXMJKASLEisHCgnR9RcQ0QR7y3e1YgghwI8nTpHYc1vY2vVyFe7kR7pA==",
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",
@@ -20218,9 +20218,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.0.30",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.30.tgz",
-      "integrity": "sha512-xbVFw4xYXN2evSvPr14PWQGJ2emUvmv5D4Fb2UlQje4kJCRAJ0q0DKjbRuFtN+rW9SJaa49wCCXbFjvlUu0fdw==",
+      "version": "5.0.31",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.31.tgz",
+      "integrity": "sha512-U0KfwWJkUkfu62HxhYmj6GXdMMb7Y5LXMJKASLEisHCgnR9RcQ0QR7y3e1YgghwI8nTpHYc1vY2vVyFe7kR7pA==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.1",
-    "next-metrics": "^5.0.30"
+    "next-metrics": "^5.0.31"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
`capi-v2-page` was added in the services on v5.0.31 
https://github.com/Financial-Times/next-metrics/commit/e282ed457b27e0f71df5e28478b944eefd180cd1