### PR TITLE
Bump next-metrics to 5.0.33

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.1",
-        "next-metrics": "^5.0.31"
+        "next-metrics": "^5.0.33"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8119,9 +8119,10 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "5.0.31",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.31.tgz",
-      "integrity": "sha512-U0KfwWJkUkfu62HxhYmj6GXdMMb7Y5LXMJKASLEisHCgnR9RcQ0QR7y3e1YgghwI8nTpHYc1vY2vVyFe7kR7pA==",
+      "version": "5.0.33",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.33.tgz",
+      "integrity": "sha512-bPOUA4lHHyT13iN/PrqPZmNRUhf/6bvHCDsN+V6ozL3yax5fursjPxUxiSlelb2XjOP1U39zE6Z3sEmbOv1n+w==",
+      "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",
@@ -8129,7 +8130,7 @@
       },
       "engines": {
         "node": "12.x",
-        "npm": "7.x"
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/next-metrics/node_modules/@financial-times/n-logger": {
@@ -20219,9 +20220,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.0.31",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.31.tgz",
-      "integrity": "sha512-U0KfwWJkUkfu62HxhYmj6GXdMMb7Y5LXMJKASLEisHCgnR9RcQ0QR7y3e1YgghwI8nTpHYc1vY2vVyFe7kR7pA==",
+      "version": "5.0.33",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.0.33.tgz",
+      "integrity": "sha512-bPOUA4lHHyT13iN/PrqPZmNRUhf/6bvHCDsN+V6ozL3yax5fursjPxUxiSlelb2XjOP1U39zE6Z3sEmbOv1n+w==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.1",
-    "next-metrics": "^5.0.31"
+    "next-metrics": "^5.0.33"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
Includes fixes to check-engines script incorrectly running during dependency install.