### PR TITLE
NOPS-836 add a check and warning for healthcheck ids

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -7,6 +7,7 @@
 const errorRateCheck = require('./error-rate-check');
 const unRegisteredServicesHealthCheck = require('./unregistered-services-healthCheck');
 const metricsHealthCheck = require('./metrics-healthcheck');
+const nLogger = require('@financial-times/n-logger').default;
 
 /**
  * @param {ExpressApp} app
@@ -34,7 +35,14 @@ module.exports = (app, options, meta) => {
 			res.set({ 'Cache-Control': 'private, no-cache, max-age=0' });
 			const checks = healthChecks.map((check) => check.getStatus());
 
-			checks.forEach(check => {if(!check.id){check.severity = 2, check.ok = false, check.panicGuide = 'Your check needs an ID, per the Health check Standard: https://docs.google.com/document/d/18hefJjImF5IFp9WvPAm9Iq5_GmWzI9ahlKSzShpQl1s/edit?usp=sharing otherwise it is of limited use. ID is an identifier for this check, unique for the given check System Code, or overall System Code.  Must only consist of lowercase alphanumeric characters and hyphens.'}})
+			checks.forEach(check => {if(!check.id){
+				nLogger.warn({
+					event: 'HEALTHCHECK_IS_MISSING_ID',
+					systemName: options.healthChecksAppName || defaultAppName,
+					systemCode: options.systemCode,
+					checkName: check.name
+				});
+			}})
 
 			if (req.params[0]) {
 				checks.forEach((check) => {


### PR DESCRIPTION
**Problem** 
Health checks that don't have an `id` set don't show their flappiness graphs in Heimdall. This isn't great because the Tech Support crew can't tell if any "down" is part of a regular flappiness or an isolated incident OR how long any "down" has lasted. 

**Solution**
This PR sets up a logger.warn so that we can track the affected health checks in Splunk