### PR TITLE
NOPS-836 add debug logs for health checks

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -44,6 +44,14 @@ module.exports = (app, options, meta) => {
 				});
 			}})
 
+			checks.forEach(check => {if(!check.ok){
+				nLogger.debug({
+					event: 'HEALTHCHECK_IS_FAILING',
+					systemCode: options.systemCode,
+					checkOutput: check.checkOutput
+				})
+			}})
+
 			if (req.params[0]) {
 				checks.forEach((check) => {
 					if (check.severity <= Number(req.params[0]) && check.ok === false) {


### PR DESCRIPTION
One of the issues the developers are facing when dealing with the flappy health checks is their ephemeral / fleeting nature - for example a next-metrics "url not registered" only reacts when said URL is triggered and it may not be "caught in the act" (so to speak) until it flaps again and someone checks it when it's failing. 

We are hoping that putting a `debug.log` with `checkOutput` (which is a string - which I think is a JSON output of the healthcheck's check) would allow us to set up capability for selective monitoring. Selective monitoring would involve changing the logger env value in Vault to "debug" and rebuilding the app we want to monitor. That way we can let an app flap and collect data and analyse the data collectively.