### PR TITLE
FTDCS-38 bump n-health to 5.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "denodeify": "^1.2.1",
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^5.0.1",
+        "n-health": "^5.0.5",
         "next-metrics": "^5.1.0"
       },
       "bin": {
@@ -7957,9 +7957,10 @@
       }
     },
     "node_modules/n-health": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-5.0.3.tgz",
-      "integrity": "sha512-Yltwf/Y4zFrnEZ4jb0icjWo4gI69GN5Pp8fkRfcWujD60XLWWGc2RB5bR0fUF25hbBYWRuOft1pYznCBFJ2LCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-5.0.5.tgz",
+      "integrity": "sha512-JzVzeRWp+5ByONW6wvFt5qIhKnzdf5c0W6R3+Ywflfb2QC3pxU0D/GRggRLQYFY/qZAaDfyJX09gt0XhHdUFdA==",
+      "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^6.0.0",
         "@financial-times/n-raven": "^2.1.0",
@@ -7970,7 +7971,8 @@
         "node-fetch": "^1.5.1"
       },
       "engines": {
-        "node": "12.x"
+        "node": "12.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/n-health/node_modules/@financial-times/n-logger": {
@@ -20087,9 +20089,9 @@
       }
     },
     "n-health": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-5.0.3.tgz",
-      "integrity": "sha512-Yltwf/Y4zFrnEZ4jb0icjWo4gI69GN5Pp8fkRfcWujD60XLWWGc2RB5bR0fUF25hbBYWRuOft1pYznCBFJ2LCw==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-5.0.5.tgz",
+      "integrity": "sha512-JzVzeRWp+5ByONW6wvFt5qIhKnzdf5c0W6R3+Ywflfb2QC3pxU0D/GRggRLQYFY/qZAaDfyJX09gt0XhHdUFdA==",
       "requires": {
         "@financial-times/n-logger": "^6.0.0",
         "@financial-times/n-raven": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^5.0.1",
+    "n-health": "^5.0.5",
     "next-metrics": "^5.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Some apps (eg next-personalapi) are using health checks though n-express, checks that rely on `asPercent`, `summarize`, and `divideSeries`. We need n-express to ingest this bump so that it correctly handles those health checks. 
For more details see https://github.com/Financial-Times/n-health/releases/tag/v5.0.5