### PR TITLE
FTDCS-37 added per-app restart check

### DIFF
--- a/src/lib/app-restart-check.js
+++ b/src/lib/app-restart-check.js
@@ -1,0 +1,36 @@
+/**
+ * @typedef {import("../../typings/n-express").ErrorRateHealthcheckOptions} ErrorRateHealthcheckOptions
+ * @typedef {import("../../typings/metrics").Healthcheck} Healthcheck
+ * @typedef {import("../../typings/metrics").TickingMetric} TickingMetric
+ */
+const nHealth = require('n-health');
+
+const DEFAULT_SEVERITY = 2;
+const DEFAULT_THRESHOLD = 20;
+
+/**
+  * @param {string} appName
+  * @param {ErrorRateHealthcheckOptions?} [opts]
+  * @returns {Healthcheck & TickingMetric}
+  */
+module.exports = (appName, opts) => {
+	opts = opts || {};
+	const severity = opts.severity || DEFAULT_SEVERITY;
+	const threshold = opts.threshold || DEFAULT_THRESHOLD;
+
+	return nHealth.runCheck(
+		{
+			id: `${appName}-restarts`,
+			name: `${appName} restart rate is normal`,
+			type: 'graphiteSpike',
+			threshold: threshold,
+			baselinePeriod: '14d',
+			samplePeriod: '1hour',
+			numerator: `next.heroku.${appName}.*.express.start`,
+			severity: severity,
+			businessImpact: 'Some part of the next platform has become severly unstable; impact can vary',
+			technicalSummary: `This alert going off means that there has been a noticeable (${threshold} times) spike in app restart rate. The reason can be innocent - merging many PRs in one day, but it also may be caused by an app stuck in a crash-restart loop.`,
+			panicGuide: 'Check Heroku app metrics for app starts to see if they correspond to PRs getting merged or error spikes. If it is error spikes, investigate for potential errors by checking this app\'s Splunk logs and Grafana dashboards.'
+		}
+	);
+};


### PR DESCRIPTION
Long time ago a check (https://github.com/Financial-Times/next-health/commit/cb25dd2baedce559afeba455773da7ab9d08e29a) was added to next-health that tracks collective app restart rates across the whole of next estate (`next.heroku.*.*.express.start`). Now, this is a reasonable check - after all we do want to know if the restarts are spiking because this could be the symptom of an app being stuck in a crash-restart loop. _But_ it also can have innocent reasons such as many PRs have been merged on a given date. 

Either way, this checks is extremely flappy, especially in the US region. This is screenshot from earlier today (16 Dec 2021)
![Screenshot 2021-12-16 at 10 56 30](https://user-images.githubusercontent.com/31079643/146391339-87a53111-b4da-4a2e-ac51-ac4d9f363e81.png)
What this means in practice is that we can't tall what app is causing this (we have a dashboard that tells us how many app restarts the busiest apps had, but it may not be representative of the problem). 

This PR moves the check from next-health to individual apps, so that we can have more granular report of which app has more restarts than average on any given day. That way we we stand a better chance at knowing what is setting off the alert.  
