### PR TITLE
FTDCS-37 wired in the restart rate healthcheck

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -6,6 +6,7 @@
  */
 
 const errorRateCheck = require('./error-rate-check');
+const appRestartCheck = require('./app-restart-check');
 const unRegisteredServicesHealthCheck = require('./unregistered-services-healthCheck');
 const metricsHealthCheck = require('./metrics-healthcheck');
 const nLogger = require('@financial-times/n-logger').default;
@@ -22,10 +23,12 @@ module.exports = (app, options, meta) => {
 
 	/** @type {Healthcheck & TickingMetric} */
 	const errorCheck = errorRateCheck(meta.graphiteName, options.errorRateHealthcheck);
+	const restartCheck = appRestartCheck(meta.graphiteName);
 
 	/** @type {Healthcheck[]} */
 	const defaultChecks = [
 		errorCheck,
+		restartCheck,
 		unRegisteredServicesHealthCheck.setAppName(meta.name),
 		metricsHealthCheck(meta.name)
 	];
@@ -53,8 +56,8 @@ module.exports = (app, options, meta) => {
 					event: 'HEALTHCHECK_IS_FAILING',
 					systemCode: options.systemCode,
 					checkOutput: check.checkOutput
-				})
-			}})
+				});
+			}});
 
 			if (req.params[0]) {
 				checks.forEach((check) => {

--- a/test/app/health.test.js
+++ b/test/app/health.test.js
@@ -10,7 +10,7 @@ describe('health', function () {
 		});
 
 		it('should not 500 /__health.2', function (done) {
-			request(defaultApp).get('/__health.2').expect(200, done);
+			request(defaultApp).get('/__health.2').expect(500, done);
 		});
 
 		it('should 500 /__health.3', function (done) {
@@ -24,7 +24,7 @@ describe('health', function () {
 		});
 
 		it('should not 500 /__health.2', function (done) {
-			request(errorRateCheckDisabledApp).get('/__health.2').expect(200, done);
+			request(errorRateCheckDisabledApp).get('/__health.2').expect(500, done);
 		});
 
 		it('should 500 /__health.3', function (done) {


### PR DESCRIPTION
Companion to #674 - because in the pre-Christmas brain-space, I added the health check but forgot to wire it in.

Q: Why are the tests changed to expect 500 in `__health.2` sections?
A: That took me rubber ducking with @rowanmanning to understand. The new check is severity 2 (at the moment we want to know when it shouts, it is likely to get downgraded later). We have this piece of code https://github.com/Financial-Times/n-express/blob/main/src/lib/health-checks.js#L61. So when I added the new check, the `__health.2` started to fail because among all the checks, there was now a check that was the more severe than all others. So the tests needed to be updated to make clear that now that we have a more severe check, the `__health.2` is expected to 500. 

In those tests, the number that follows the `__health.` is the severity level. 