### PR TITLE
FTDCS-37 Fix the restart check tests

### DIFF
--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -99,6 +99,7 @@ module.exports = class InstrumentListen {
 	}
 
 	addMetrics (item) {
-		this.tickingMetrics.push(item);
+		const items = (Array.isArray(item) ? item : [item]);
+		this.tickingMetrics.push(...items);
 	}
 };

--- a/test/app/clear-interval.test.js
+++ b/test/app/clear-interval.test.js
@@ -13,16 +13,19 @@ describe('clears intervals', () => {
 		result.stop();
 	});
 
-	it('should return object with stop function in health-checks', () => {
+	it('should return an array of objects with stop functions in health-checks', () => {
 		const app = express();
 
-		const result = healthChecks(app, {healthChecks: []}, {});
-		expect(result.stop).to.not.be.undefined;
+		const checks = healthChecks(app, {healthChecks: []}, {});
+		expect(checks).to.be.an('array');
+		for (const check of checks) {
+			expect(check.stop).to.be.a('function');
+		}
 
 		//ensure the start() function is called before the stop(),
 		//because healthChecks(...) eventually calls n-health runCheck(), but runCheck() doesn't await on start()
 		setTimeout(() => {
-			result.stop();
+			checks.forEach(check => check.stop());
 		}, 0);
 	});
 


### PR DESCRIPTION
This addresses the test failures introduced in #675, which were caused
because we were expecting only a single health check to be exported by
the `health-checks` module.

After a discussion with @serena97 and @ivomurrell, we decided to
refactor the `health-checks` module to export and array of checks,
and update `InstrumentListen#addMetrics` to accept either an array
or a single item.

Let me know if anything isn't quite right, happy to make any code
style changes too (it's been a while!)