### PR TITLE
[FTDCS-37] Update app restart check

### DIFF
--- a/src/lib/app-restart-check.js
+++ b/src/lib/app-restart-check.js
@@ -16,22 +16,22 @@ module.exports = (appName, opts) => {
 	opts = opts || {};
 	const severity = opts.severity || DEFAULT_SEVERITY;
 
-	let region_name, dyno_matcher;
+	let regionName, dynoMatcher;
 
 	if (process.env.REGION) {
-		region_name = process.env.REGION.toUpperCase();
-		dyno_matcher = `*_${region_name}`;
+		regionName = process.env.REGION.toUpperCase();
+		dynoMatcher = `*_${regionName}`;
 	} else {
-		region_name = 'unknown region';
-		dyno_matcher = '*';
+		regionName = 'unknown region';
+		dynoMatcher = '*';
 	}
 
-	const applicationStartMetric = `next.heroku.${appName}.${dyno_matcher}.express.start`;
+	const applicationStartMetric = `next.heroku.${appName}.${dynoMatcher}.express.start`;
 
 	return nHealth.runCheck(
 		{
 			id: `${appName}-restarts`,
-			name: `${appName} restart rate is normal (${region_name})`,
+			name: `${appName} restart rate is normal (${regionName})`,
 			type: 'graphiteThreshold',
 			threshold: 2,
 			samplePeriod: '6hours',

--- a/src/lib/app-restart-check.js
+++ b/src/lib/app-restart-check.js
@@ -18,15 +18,25 @@ module.exports = (appName, opts) => {
 	const severity = opts.severity || DEFAULT_SEVERITY;
 	const threshold = opts.threshold || DEFAULT_THRESHOLD;
 
+	let region_name, dyno_matcher;
+
+	if (process.env.REGION) {
+		region_name = process.env.REGION.toUpperCase();
+		dyno_matcher = `*_${region_name}`;
+	} else {
+		region_name = 'unknown region';
+		dyno_matcher = '*';
+	}
+
 	return nHealth.runCheck(
 		{
 			id: `${appName}-restarts`,
-			name: `${appName} restart rate is normal`,
+			name: `${appName} restart rate is normal (${region_name})`,
 			type: 'graphiteSpike',
 			threshold: threshold,
 			baselinePeriod: '14d',
 			samplePeriod: '1hour',
-			numerator: `next.heroku.${appName}.*.express.start`,
+			numerator: `next.heroku.${appName}.${dyno_matcher}.express.start`,
 			severity: severity,
 			businessImpact: 'Some part of the next platform has become severly unstable; impact can vary',
 			technicalSummary: `This alert going off means that there has been a noticeable (${threshold} times) spike in app restart rate. The reason can be innocent - merging many PRs in one day, but it also may be caused by an app stuck in a crash-restart loop.`,

--- a/src/lib/app-restart-check.js
+++ b/src/lib/app-restart-check.js
@@ -6,7 +6,6 @@
 const nHealth = require('n-health');
 
 const DEFAULT_SEVERITY = 2;
-const DEFAULT_THRESHOLD = 20;
 
 /**
   * @param {string} appName
@@ -16,7 +15,6 @@ const DEFAULT_THRESHOLD = 20;
 module.exports = (appName, opts) => {
 	opts = opts || {};
 	const severity = opts.severity || DEFAULT_SEVERITY;
-	const threshold = opts.threshold || DEFAULT_THRESHOLD;
 
 	let region_name, dyno_matcher;
 
@@ -28,18 +26,19 @@ module.exports = (appName, opts) => {
 		dyno_matcher = '*';
 	}
 
+	const applicationStartMetric = `next.heroku.${appName}.${dyno_matcher}.express.start`;
+
 	return nHealth.runCheck(
 		{
 			id: `${appName}-restarts`,
 			name: `${appName} restart rate is normal (${region_name})`,
-			type: 'graphiteSpike',
-			threshold: threshold,
-			baselinePeriod: '14d',
-			samplePeriod: '1hour',
-			numerator: `next.heroku.${appName}.${dyno_matcher}.express.start`,
+			type: 'graphiteThreshold',
+			threshold: 2,
+			samplePeriod: '6hours',
+			metric: `transformNull(summarize(${applicationStartMetric}, '1h'), 0)`,
 			severity: severity,
-			businessImpact: 'Some part of the next platform has become severly unstable; impact can vary',
-			technicalSummary: `This alert going off means that there has been a noticeable (${threshold} times) spike in app restart rate. The reason can be innocent - merging many PRs in one day, but it also may be caused by an app stuck in a crash-restart loop.`,
+			businessImpact: `Parts of the site that depend on '${appName}' may be unstable`,
+			technicalSummary: `This alert going off means that a dyno is restarting more frequently than we expect. The reason can be innocent - merging many PRs in one day, but it also may be caused by an app stuck in a crash-restart loop.`,
 			panicGuide: 'Check Heroku app metrics for app starts to see if they correspond to PRs getting merged or error spikes. If it is error spikes, investigate for potential errors by checking this app\'s Splunk logs and Grafana dashboards.'
 		}
 	);

--- a/test/app/app-restart-check.test.js
+++ b/test/app/app-restart-check.test.js
@@ -1,0 +1,58 @@
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+const nHealthStub = {
+	runCheck: sinon.stub()
+};
+
+const subject = proxyquire('../../src/lib/app-restart-check', {
+	'n-health': nHealthStub
+});
+
+describe('Default app restart check', () => {
+	let env;
+
+	before(() => {
+		env = Object.assign({}, process.env);
+	});
+
+	after(() => {
+		process.env = env;
+	});
+
+	it('uses sensible defaults when the region is unavailable', () => {
+		delete process.env.REGION;
+
+		subject('app-name');
+		expect(nHealthStub.runCheck).calledWithMatch({
+			name: 'app-name restart rate is normal (unknown region)',
+			metric: "transformNull(summarize(next.heroku.app-name.*.express.start, '1h'), 0)",
+			threshold: 2,
+			samplePeriod: '6hours',
+			severity: 2,
+		})
+	});
+
+	it('queries restarts in a specific region if REGION is specified in the environment', () => {
+		process.env.REGION = 'eu';
+
+		subject('app-name');
+		expect(nHealthStub.runCheck).calledWithMatch({
+			name: 'app-name restart rate is normal (EU)',
+			metric: "transformNull(summarize(next.heroku.app-name.*_EU.express.start, '1h'), 0)",
+		})
+	});
+
+	it('allows severity to be customised with options', () => {
+		subject('app-name', {
+			severity: 3,
+		});
+		expect(nHealthStub.runCheck).calledWithMatch({
+			severity: 3,
+		})
+	});
+});


### PR DESCRIPTION
Commits:

- Change the metric that we're testing so that it's based on region
- Use a graphite threshold instead of spike - for consistency/reliability

The way the `graphiteThreshold` check works is a little confusing at first but very good for us:

- The wildcard matcher (for example `*_EU`) will match all dynos for a given app
- Graphite will return multiple series for this query (`dyno_1_EU`, `dyno_2_EU`, etc)
- The graphiteThreshold check will iterate over all these series and check if any of them are above a given value
- I have used the `summarize()` function to group these series into 1 hour buckets, and `transformNull()` to set null data (no restarts) to 0
- The samplePeriod means that we go back 6 hours (6 metrics per dyno)

I reckon if a dyno restarted more than 2 times in a one hour period that would be a good indication of a problem.