### PR TITLE
Bump up next-metrics version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.5",
-        "next-metrics": "^5.1.0"
+        "next-metrics": "^5.1.4"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8124,13 +8124,13 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.0.tgz",
-      "integrity": "sha512-wAhtV9LmXKxbHM4ELF6cFLYvu5w0wt99U/LB6VmFBRjnVaI57kCtIptR4yGdViCxVViok5+1MU5PYvq0VDYYug==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.4.tgz",
+      "integrity": "sha512-BhpEyfm42f7rmRJbAzFI58Mz7WcYvxAkNpLH6Ubq8ynH9mFjbgqf4uHUTpjyDKjK09tqtx4KaCom4yGdrUEL5g==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       },
       "engines": {
@@ -20225,12 +20225,12 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.0.tgz",
-      "integrity": "sha512-wAhtV9LmXKxbHM4ELF6cFLYvu5w0wt99U/LB6VmFBRjnVaI57kCtIptR4yGdViCxVViok5+1MU5PYvq0VDYYug==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.4.tgz",
+      "integrity": "sha512-BhpEyfm42f7rmRJbAzFI58Mz7WcYvxAkNpLH6Ubq8ynH9mFjbgqf4uHUTpjyDKjK09tqtx4KaCom4yGdrUEL5g==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.5",
-    "next-metrics": "^5.1.0"
+    "next-metrics": "^5.1.4"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
to resolve a next-api vulnerability issue.
The detail is [in the PR for next-metrics](https://github.com/Financial-Times/next-metrics/pull/449)