### PR TITLE
ACQ-1448: update next-metrics to 5.2.0 to stop next-metrics alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.5",
-        "next-metrics": "^5.1.4"
+        "next-metrics": "^5.2.0"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8124,9 +8124,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.4.tgz",
-      "integrity": "sha512-BhpEyfm42f7rmRJbAzFI58Mz7WcYvxAkNpLH6Ubq8ynH9mFjbgqf4uHUTpjyDKjK09tqtx4KaCom4yGdrUEL5g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.2.0.tgz",
+      "integrity": "sha512-sYop2MHSgm079HKDv2uhOgY7suhLl8VYY+EEm41Kk1cTXGN1iuMvT4WZTlSm6jGXVd7cMgcIRwXviy9Wu+P8TQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
@@ -20225,9 +20225,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.1.4.tgz",
-      "integrity": "sha512-BhpEyfm42f7rmRJbAzFI58Mz7WcYvxAkNpLH6Ubq8ynH9mFjbgqf4uHUTpjyDKjK09tqtx4KaCom4yGdrUEL5g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.2.0.tgz",
+      "integrity": "sha512-sYop2MHSgm079HKDv2uhOgY7suhLl8VYY+EEm41Kk1cTXGN1iuMvT4WZTlSm6jGXVd7cMgcIRwXviy9Wu+P8TQ==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.5",
-    "next-metrics": "^5.1.4"
+    "next-metrics": "^5.2.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
update next-metrics to 5.2.0 to stop next-metrics alerts
https://financialtimes.atlassian.net/browse/ACQ-1448
https://financialtimes.atlassian.net/browse/ACQ-1451