### PR TITLE
FTDCS-86 - Add express.urlencoded to exports

### DIFF
--- a/main.js
+++ b/main.js
@@ -179,6 +179,7 @@ module.exports = (options) => getAppContainer(options).app;
 
 // expose internals the app may want access to
 module.exports.json = express.json;
+module.exports.urlencoded = express.urlencoded;
 module.exports.Router = express.Router;
 module.exports.static = express.static;
 module.exports.metrics = metrics;


### PR DESCRIPTION
Express version 4.16+ has its own body-parser implementation included in the default Express package so there is no need to add another dependency.
The 2 most used functions of body-parser along the projects are `json` and `urlencoded`.
Adding `urlencoded` to the exports of n-express allows us to remove the body-parser dependency from all (or at least most) of the projects.