### PR TITLE
Upgrade next-metrics from 5.2.0 to 6.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.5",
-        "next-metrics": "^5.2.0"
+        "next-metrics": "^6.0.1"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -44,7 +44,7 @@
         "typescript": "4.3.5"
       },
       "engines": {
-        "node": "12.x",
+        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -8124,9 +8124,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.2.0.tgz",
-      "integrity": "sha512-sYop2MHSgm079HKDv2uhOgY7suhLl8VYY+EEm41Kk1cTXGN1iuMvT4WZTlSm6jGXVd7cMgcIRwXviy9Wu+P8TQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.0.1.tgz",
+      "integrity": "sha512-1pihakte/zUvXmYeroQI/57CXKxtQf/ENBu7aJk3oQ35mY9hi1xCcGUn3oFolcmwdeC+EGLhOJ/dPmzijHDcVA==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
@@ -8134,7 +8134,7 @@
         "metrics": "^0.1.8"
       },
       "engines": {
-        "node": "12.x",
+        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -20225,9 +20225,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-5.2.0.tgz",
-      "integrity": "sha512-sYop2MHSgm079HKDv2uhOgY7suhLl8VYY+EEm41Kk1cTXGN1iuMvT4WZTlSm6jGXVd7cMgcIRwXviy9Wu+P8TQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.0.1.tgz",
+      "integrity": "sha512-1pihakte/zUvXmYeroQI/57CXKxtQf/ENBu7aJk3oQ35mY9hi1xCcGUn3oFolcmwdeC+EGLhOJ/dPmzijHDcVA==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.5",
-    "next-metrics": "^5.2.0"
+    "next-metrics": "^6.0.1"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
https://github.com/financial-times/next-metrics/compare/v5.2.0...v6.0.1

This is a major version bump of next-metrics but the Node.js engines match what n-express would like so I don't think there's any issue.

Will do this as a patch release of n-express unless somebody tells me otherwise.