### PR TITLE
ACQ-1536: add a new property to anon model

### DIFF
--- a/src/middleware/anon.js
+++ b/src/middleware/anon.js
@@ -7,17 +7,20 @@
 /**
  * @type {Callback}
  */
-function AnonymousModel(req) {
+function AnonymousModel (req) {
 	if (req.get('FT-Anonymous-User') === 'true') {
 		this.userIsLoggedIn = false;
 		this.userIsAnonymous = true;
+		this.userIsSubscribed = false;
 	} else {
 		this.userIsLoggedIn = true;
 		this.userIsAnonymous = false;
+		// set by ammit task in preflight
+		this.userIsSubscribed = req.get('ft-user-subscription-status') === 'subscribed';
 	}
 }
 
-function FirstClickFreeModel() {
+function FirstClickFreeModel () {
 	this.signInLink = '/login';
 }
 
@@ -30,7 +33,7 @@ const anonModels = {
  * @param {Request} req
  * @param {Response} res
  */
-function showFirstClickFree(req, res) {
+function showFirstClickFree (req, res) {
 	return (
 		res.locals.flags.firstClickFree &&
 		req.get('FT-Access-Decision') === 'GRANTED' &&
@@ -41,7 +44,7 @@ function showFirstClickFree(req, res) {
 /**
  * @type {Callback}
  */
-function anonymousMiddleware(req, res, next) {
+function anonymousMiddleware (req, res, next) {
 	res.locals.anon = new anonModels.AnonymousModel(req);
 	res.locals.firstClickFreeModel = showFirstClickFree(req, res)
 		? new anonModels.FirstClickFreeModel()

--- a/test/middleware/anon.test.js
+++ b/test/middleware/anon.test.js
@@ -35,6 +35,21 @@ describe('Anonymous Middleware', function () {
 			.set('FT-Anonymous-User', 'true')
 			.expect(function () {
 				expect(locals.anon.userIsAnonymous).to.be.true;
+				expect(locals.anon.userIsLoggedIn).to.be.false;
+				expect(locals.anon.userIsSubscribed).to.be.false;
+			})
+			.end(done);
+	});
+
+	it('Should set the res.locals.userIsSubscribed property based on the ft-user-subscription-status header', function (done) {
+		request(app)
+			.get('/')
+			.set('FT-Anonymous-User', 'false')
+			.set('ft-user-subscription-status', 'subscribed')
+			.expect(function () {
+				expect(locals.anon.userIsAnonymous).to.be.false;
+				expect(locals.anon.userIsLoggedIn).to.be.true;
+				expect(locals.anon.userIsSubscribed).to.be.true;
 			})
 			.end(done);
 	});


### PR DESCRIPTION
As part of the following tasks https://financialtimes.atlassian.net/browse/ACQ-1393, we want to render different components based on user status in homepage, in particular, know whether the user is under the following categories: anonymous, registered, subscribed.

In that sense we want to include this information [provided by preflight](https://github.com/Financial-Times/next-preflight/blob/0157653677c5aa834bf9051393f3a6b7959f1249/server/tasks/next/ammit.js#L43) as part of anon model which is available for the rest of the journey in order to make those kind of decisions.

At the moment we have already isUserLoggedIn which allow us to know if the user is anon or not, so by adding this new field isUserSubscribed we can distinguish the other two status registered and subscribed.