### PR TITLE
Add Possibility to use node-fetch instead isomorphic fetch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
-          version: "7"
+          version: "7.20.2"
       - run:
           name: Install project dependencies
           command: make install

--- a/main.js
+++ b/main.js
@@ -172,6 +172,16 @@ const getAppContainer = (options) => {
 };
 
 /**
+ * This method replace global.fetch variable with node-fetch instance .
+ * It must to be call before init the server in order to behave well
+ */
+const useNodeFetch = () => {
+	const nodeFetch = require('node-fetch');
+	global.fetch = nodeFetch;
+	global.fetch.isNodeFetch = true;
+};
+
+/**
  * @param {AppOptions} options
  * @returns {Application}
  */
@@ -185,3 +195,4 @@ module.exports.static = express.static;
 module.exports.metrics = metrics;
 module.exports.flags = flags;
 module.exports.getAppContainer = getAppContainer;
+module.exports.useNodeFetch = useNodeFetch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "express": "^4.16.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^5.0.5",
-        "next-metrics": "^6.0.3"
+        "next-metrics": "^6.0.3",
+        "node-fetch": "^1.7.3"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8141,7 +8142,7 @@
     "node_modules/next-metrics/node_modules/@financial-times/n-logger": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-5.7.2.tgz",
-      "integrity": "sha1-tR/WW6c4FdklaEQUl2yQOIUZsU8=",
+      "integrity": "sha512-MoTlTU5Zqge5ZeoHYbdfFAxKsMxBfrmWRD60QrUb3O+RBHtTkjySYX0lSP2SZQ7FbiVw/sYJokouvz/DYnDXVQ==",
       "dependencies": {
         "isomorphic-fetch": "^2.2.1",
         "request": "^2.83.0",
@@ -20237,7 +20238,7 @@
         "@financial-times/n-logger": {
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-5.7.2.tgz",
-          "integrity": "sha1-tR/WW6c4FdklaEQUl2yQOIUZsU8=",
+          "integrity": "sha512-MoTlTU5Zqge5ZeoHYbdfFAxKsMxBfrmWRD60QrUb3O+RBHtTkjySYX0lSP2SZQ7FbiVw/sYJokouvz/DYnDXVQ==",
           "requires": {
             "isomorphic-fetch": "^2.2.1",
             "request": "^2.83.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "express": "^4.16.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^5.0.5",
-    "next-metrics": "^6.0.3"
+    "next-metrics": "^6.0.3",
+    "node-fetch": "^1.7.3"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",

--- a/test/app/usenodefetch.test.js
+++ b/test/app/usenodefetch.test.js
@@ -1,0 +1,32 @@
+/*global it, global, describe, before, after*/
+const expect = require('chai').expect;
+
+
+let app;
+
+describe('useNodeFetch tests', function () {
+	before(() => {
+		app = require('../../main.js');
+	});
+
+	it('It use by default isomorfic fetch ',function (){
+		expect(global.fetch).to.not.be.undefined;
+		expect(global.fetch).to.not.be.null;
+		expect(global.fetch.isNodeFecth).to.be.undefined;
+
+	});
+
+	it('set node fetch as fetch object ',function (){
+		const old_fetch = global.fetch;
+		app.useNodeFetch();
+		expect(global.fetch).to.not.be.undefined;
+		expect(global.fetch).to.not.be.null;
+		expect(global.fetch.isNodeFetch).to.equal(true);
+		expect(global.fetch).not.equal(old_fetch);
+	});
+
+
+	after(() => {
+		app.useNodeFetch(false);
+	});
+});


### PR DESCRIPTION
Node-fetch is been used in some projects due it has more capabilities than isomorphic fetch. This causes that the additonal modifications that we do the fetch library like instrumenting with next-metrics is not been done, so metrics are not send .

Due to Isomorphic fetch modifies global.fetch we are setting in this variable the node-fetch if useNodeFetch is called in order to not affect other apps that use n-express

