### PR TITLE
FTDCS-188 - Fix CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
-          version: "7"
+          version: "^7"
       - run:
           name: Install project dependencies
           command: make install


### PR DESCRIPTION
Fix CircleCI configuration to avoid error `✘ npm version is incorrect! Expected 7.x || 8.x but was 6.14.17.`