### PR TITLE
FTDCS-188 - Add system code the debug headers

### DIFF
--- a/main.js
+++ b/main.js
@@ -114,6 +114,7 @@ const getAppContainer = (options) => {
 		/** @type {Callback} */ (req, res, next) => {
 			res.set('FT-App-Name', meta.name);
 			res.set('FT-Backend-Timestamp', new Date().toISOString());
+			res.set('FT-System-Code', meta.systemCode);
 			next();
 		}
 	);


### PR DESCRIPTION
We need to associate Fastly logs with systems. 
This currently isn’t possible - the worst example is next-stream-page (in Fastly logs, there’s no way to figure out that /world is served by next-stream-page.
We should surface this data in Fastly so that we can group errors by system.