### PR TITLE
Bump next-metrics to 6.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^6.1.0",
-        "next-metrics": "^6.0.3"
+        "next-metrics": "^6.1.2"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8228,9 +8228,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.0.3.tgz",
-      "integrity": "sha512-ZYm9xo6ryC3ZHOPR4ABlXyw5d2+wCu5QbegDJt23pG5qRLDWraJxUyvc1v6s0aYhfOed2abSl0bwEIpSxY6VUg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.1.2.tgz",
+      "integrity": "sha512-KCf2/P0gwnvgwtJE/Wn3FBL04+am1BX8x8xVo3JMQywxhzZpOjmtSX4/ldEnt3g/3OIbwe22vQFdJaI4JRMhyA==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
@@ -20423,9 +20423,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.0.3.tgz",
-      "integrity": "sha512-ZYm9xo6ryC3ZHOPR4ABlXyw5d2+wCu5QbegDJt23pG5qRLDWraJxUyvc1v6s0aYhfOed2abSl0bwEIpSxY6VUg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.1.2.tgz",
+      "integrity": "sha512-KCf2/P0gwnvgwtJE/Wn3FBL04+am1BX8x8xVo3JMQywxhzZpOjmtSX4/ldEnt3g/3OIbwe22vQFdJaI4JRMhyA==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^6.1.0",
-    "next-metrics": "^6.0.3"
+    "next-metrics": "^6.1.2"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
Version 6.1.2 includes new services that are called within next-es-interface and therefore need to be registered