### PR TITLE
ACC-1799 metrics bump to ingest newsletter regex improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^6.1.0",
-        "next-metrics": "^6.1.2"
+        "next-metrics": "^6.1.3"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8228,9 +8228,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.1.2.tgz",
-      "integrity": "sha512-KCf2/P0gwnvgwtJE/Wn3FBL04+am1BX8x8xVo3JMQywxhzZpOjmtSX4/ldEnt3g/3OIbwe22vQFdJaI4JRMhyA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.1.3.tgz",
+      "integrity": "sha512-zcaRti0A3xdskjS0TMVkvM5ZUSuZdWdDhLwfDQ5w+x/y4FWYSIGuwudM/mxCsefgTzwZ6tBFJ76AjVz5xRkD1w==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
@@ -20423,9 +20423,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.1.2.tgz",
-      "integrity": "sha512-KCf2/P0gwnvgwtJE/Wn3FBL04+am1BX8x8xVo3JMQywxhzZpOjmtSX4/ldEnt3g/3OIbwe22vQFdJaI4JRMhyA==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-6.1.3.tgz",
+      "integrity": "sha512-zcaRti0A3xdskjS0TMVkvM5ZUSuZdWdDhLwfDQ5w+x/y4FWYSIGuwudM/mxCsefgTzwZ6tBFJ76AjVz5xRkD1w==",
       "requires": {
         "@financial-times/n-logger": "^5.5.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^6.1.0",
-    "next-metrics": "^6.1.2"
+    "next-metrics": "^6.1.3"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
Ingests https://github.com/Financial-Times/next-metrics/pull/468 so that next-newsletters-page can use it.

https://financialtimes.atlassian.net/browse/ACC-1799