### PR TITLE
Upgrade next-metrics from v7.0.0 to v7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^6.2.0",
-        "next-metrics": "^7.0.0"
+        "next-metrics": "^7.1.0"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -8130,9 +8130,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.0.0.tgz",
-      "integrity": "sha512-Wq1RMo/d5USvS2ke7SLTpYCTFV1hqXwPy25pkcAo8Jt3CaRT6a6a6v6/loLWoRl6MlY7frGMxXdRktpKnsZ3dA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.1.0.tgz",
+      "integrity": "sha512-ufc0BFDpg4ekeNzfYJiZVtruXPbpkDUJsC57dfvVNQ1iL3mogq3oYkuXfDsMTEWlR5mgVCdKcTSV30FrDrUmIw==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -20235,9 +20235,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.0.0.tgz",
-      "integrity": "sha512-Wq1RMo/d5USvS2ke7SLTpYCTFV1hqXwPy25pkcAo8Jt3CaRT6a6a6v6/loLWoRl6MlY7frGMxXdRktpKnsZ3dA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.1.0.tgz",
+      "integrity": "sha512-ufc0BFDpg4ekeNzfYJiZVtruXPbpkDUJsC57dfvVNQ1iL3mogq3oYkuXfDsMTEWlR5mgVCdKcTSV30FrDrUmIw==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^6.2.0",
-    "next-metrics": "^7.0.0"
+    "next-metrics": "^7.1.0"
   },
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",


### PR DESCRIPTION
This includes the Heroku Metrics API in services.js which we need for next-health.