### PR TITLE
Add a message property to all logs

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -53,6 +53,7 @@ module.exports = (app, options, meta) => {
 			checks.forEach(check => {if(!check.id){
 				nLogger.warn({
 					event: 'HEALTHCHECK_IS_MISSING_ID',
+					message: `The ${check.name} healthcheck is missing an ID`,
 					systemName: options.healthChecksAppName || defaultAppName,
 					systemCode: options.systemCode,
 					checkName: check.name
@@ -62,6 +63,7 @@ module.exports = (app, options, meta) => {
 			checks.forEach(check => {if(!check.ok){
 				nLogger.debug({
 					event: 'HEALTHCHECK_IS_FAILING',
+					message: `The ${check.name} healthcheck is failing`,
 					systemCode: options.systemCode,
 					checkOutput: check.checkOutput
 				});

--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -61,6 +61,7 @@ module.exports = class InstrumentListen {
 				// HACK: Use warn so that it gets into Splunk logs
 				nLogger.warn({
 					event: 'EXPRESS_START',
+					message: `Express application ${meta.name} started`,
 					app: meta.name,
 					port: port,
 					nodeVersion: process.version


### PR DESCRIPTION
With the move to Splunk log drains, we're now seeing messages as empty
strings at the top level. We think it's always useful to have a
human-readable summary of the log so that they can be skim-read while
debugging issues.