### PR TITLE
Add a default Heroku log drain health check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^6.2.0",
+        "n-health": "^6.3.0",
         "next-metrics": "^7.1.0"
       },
       "bin": {
@@ -8059,9 +8059,9 @@
       }
     },
     "node_modules/n-health": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-6.2.0.tgz",
-      "integrity": "sha512-Bo/nEYBwAwNcyow10lmkrTTJpl4Jz9VnxCageRn6db5g1b8yozZBclAbAYQhJG/BS5Ub8FZGlW62+c3/4I+C6Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-6.3.0.tgz",
+      "integrity": "sha512-8OQBADNuDl8aCtzN5ABT5iR0Qp945+l/NWpGUf/aLtbmqngrNnlSFv1KVvhKIAHFMC0/z5R71K5toOrereQg/A==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -20176,9 +20176,9 @@
       }
     },
     "n-health": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-6.2.0.tgz",
-      "integrity": "sha512-Bo/nEYBwAwNcyow10lmkrTTJpl4Jz9VnxCageRn6db5g1b8yozZBclAbAYQhJG/BS5Ub8FZGlW62+c3/4I+C6Q==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-6.3.0.tgz",
+      "integrity": "sha512-8OQBADNuDl8aCtzN5ABT5iR0Qp945+l/NWpGUf/aLtbmqngrNnlSFv1KVvhKIAHFMC0/z5R71K5toOrereQg/A==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^6.2.0",
+    "n-health": "^6.3.0",
     "next-metrics": "^7.1.0"
   },
   "devDependencies": {

--- a/src/lib/heroku-log-drain-check.js
+++ b/src/lib/heroku-log-drain-check.js
@@ -16,7 +16,7 @@ module.exports = (opts) => {
 
 	return nHealth.runCheck({
 		id: `heroku-log-drain-${region}`,
-		name: 'Heroku log drain configured',
+		name: `Heroku log drain configured (${region.toUpperCase()})`,
 		type: 'herokuLogDrain',
 		severity: opts.severity
 	});

--- a/src/lib/heroku-log-drain-check.js
+++ b/src/lib/heroku-log-drain-check.js
@@ -1,0 +1,23 @@
+/**
+ * @typedef {import("../../typings/n-express").HerokuLogDrainHealthcheckOptions} HerokuLogDrainHealthcheckOptions
+ * @typedef {import("../../typings/metrics").Healthcheck} Healthcheck
+ * @typedef {import("../../typings/metrics").TickingMetric} TickingMetric
+ */
+const nHealth = require('n-health');
+
+/**
+ * @param {HerokuLogDrainHealthcheckOptions?} [opts]
+ * @returns {Healthcheck & TickingMetric}
+ */
+module.exports = (opts) => {
+	opts = opts || {};
+
+	const region = process.env.REGION === 'US' ? 'us' : 'eu';
+
+	return nHealth.runCheck({
+		id: `heroku-log-drain-${region}`,
+		name: 'Heroku log drain configured',
+		type: 'herokuLogDrain',
+		severity: opts.severity
+	});
+};

--- a/test/app/heroku-log-drain-check.test.js
+++ b/test/app/heroku-log-drain-check.test.js
@@ -30,7 +30,7 @@ describe('Heroku log drain check', () => {
 		expect(nHealth.runCheck.firstCall.args.length).to.equal(1);
 		expect(nHealth.runCheck.firstCall.args[0]).to.deep.equal({
 			id: 'heroku-log-drain-eu',
-			name: 'Heroku log drain configured',
+			name: 'Heroku log drain configured (EU)',
 			type: 'herokuLogDrain',
 			severity: 'mock-severity'
 		});
@@ -48,6 +48,10 @@ describe('Heroku log drain check', () => {
 
 		it('suffixes the check ID with "us"', () => {
 			expect(nHealth.runCheck.firstCall.args[0].id).to.equal('heroku-log-drain-us');
+		});
+
+		it('suffixes the check name with "(US)"', () => {
+			expect(nHealth.runCheck.firstCall.args[0].name).to.equal('Heroku log drain configured (US)');
 		});
 
 	});

--- a/test/app/heroku-log-drain-check.test.js
+++ b/test/app/heroku-log-drain-check.test.js
@@ -1,0 +1,55 @@
+const {expect} = require('chai');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const nHealth = {
+	runCheck: sinon.stub().returns('mock-check')
+};
+
+const herokuLogDrainCheck = proxyquire('../../src/lib/heroku-log-drain-check', {
+	'n-health': nHealth
+});
+
+describe('Heroku log drain check', () => {
+	let originalEnv;
+
+	beforeEach(() => {
+		originalEnv = Object.assign({}, process.env);
+		delete process.env.REGION;
+		herokuLogDrainCheck({
+			severity: 'mock-severity'
+		});
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('runs a Heroku log drain check', () => {
+		expect(nHealth.runCheck.callCount).to.equal(1);
+		expect(nHealth.runCheck.firstCall.args.length).to.equal(1);
+		expect(nHealth.runCheck.firstCall.args[0]).to.deep.equal({
+			id: 'heroku-log-drain-eu',
+			name: 'Heroku log drain configured',
+			type: 'herokuLogDrain',
+			severity: 'mock-severity'
+		});
+	});
+
+	describe('when the `REGION` environment variable is set to "US"', () => {
+
+		beforeEach(() => {
+			nHealth.runCheck.resetHistory();
+			process.env.REGION = 'US';
+			herokuLogDrainCheck({
+				severity: 'mock-severity'
+			});
+		});
+
+		it('suffixes the check ID with "us"', () => {
+			expect(nHealth.runCheck.firstCall.args[0].id).to.equal('heroku-log-drain-us');
+		});
+
+	});
+
+});

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -51,6 +51,12 @@ export interface ErrorRateHealthcheckOptions {
 	samplePeriod?: string;
 }
 
+export interface HerokuLogDrainHealthcheckOptions {
+	severity?: number;
+	herokuAuthToken?: string;
+	herokuAppId?: string;
+}
+
 export interface AppContainer {
 	app: Express.Application;
 	meta: guessAppDetails.Options & {


### PR DESCRIPTION
This uses the new Heroku log drain check which allows us to see alerts
for an app if it's expecting to use log drains but they're misconfigured
in some way. This default check is only enabled if an app has the
`MIGRATE_TO_HEROKU_LOG_DRAINS` environment variable set so it won't
start failing for apps which haven't conciously opted into log drains
(See https://github.com/Financial-Times/n-logger/pull/152 for more info).

There's a note in the source explaining that this condition will be
removed in future. I think this is a minor change as the health check
will only start failing when an app opts in.

Relates-To: FTDCS-218