### PR TITLE
Bump n-raven and n-health

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@financial-times/n-flags-client": "^11.1.0",
         "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.2.0",
+        "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^6.3.0",
+        "n-health": "^7.0.0",
         "next-metrics": "^7.1.0"
       },
       "bin": {
@@ -419,6 +419,38 @@
       "integrity": "sha512-DPgxtHuJwBORpqRkPXzzOT+uoPRVJmaN7LR+pmeL6DQM90kj6G6GFUH1i/YpRH8NbML8ZGEDwB9f9u4UwD2pzg==",
       "dev": true
     },
+    "node_modules/@dotcom-reliability-kit/log-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.3.0.tgz",
+      "integrity": "sha512-3VjGttJoMcurPJO2iL5Cx42xz3PiSSfzXLQjPa0rHqPXKiPdZAsIc3LyJjtUNaU8pav60RUtj1pUpeEy596b6Q==",
+      "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": "^1.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^1.0.0",
+        "@financial-times/n-logger": "^10.2.0"
+      },
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.0.0.tgz",
+      "integrity": "sha512-ROU7khyWTAIgQf3IzmLwjF5K5CT/pctzxMEr6gG2TmL2L4ahsjxGjq0kt6J8n87lLTAJWy+bu+JpC7c0MJJP1g==",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.0.0.tgz",
+      "integrity": "sha512-1g1LteXQbBQfBZj/bekRIbuREGOKaehXJG3oI7779vYhh7X3f5ohGSjJww1GyPclT9dNkelno4MHDQaJOWngqA==",
+      "engines": {
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "node_modules/@financial-times/eslint-config-next": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
@@ -554,11 +586,12 @@
       }
     },
     "node_modules/@financial-times/n-raven": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.2.0.tgz",
-      "integrity": "sha512-GJSrqCvlSAtd8Zqolo2UAefjxiNKwIhbaPlBghCtHa9XG2KiVF6QeBLVf3iObKLuxuk4BgIRP4Ec/so2c8vD2g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
+      "integrity": "sha512-UnybNv9iriGO1PxAffIUyuU9rRsb788mt12YVBbnawHdCeqPEx2TVqSnMkF6wSM5BLosWh4tB4GmwJgbPErZnw==",
       "hasInstallScript": true,
       "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^1.3.0",
         "@financial-times/n-logger": "^10.2.0",
         "raven": "^2.3.0"
       },
@@ -8059,13 +8092,12 @@
       }
     },
     "node_modules/n-health": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-6.3.0.tgz",
-      "integrity": "sha512-8OQBADNuDl8aCtzN5ABT5iR0Qp945+l/NWpGUf/aLtbmqngrNnlSFv1KVvhKIAHFMC0/z5R71K5toOrereQg/A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.0.tgz",
+      "integrity": "sha512-cr3ooRtMyx0YVy9Gl8MDJXoPZ9nTkxmyngLYyjQVjzN0mLeSI37TvjC+CviWyfAJzBL/rzGgvNIhyU0IXESPww==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.2.0",
         "aws-sdk": "^2.6.10",
         "fetchres": "^1.5.1",
         "moment": "^2.29.4",
@@ -14129,6 +14161,26 @@
       "integrity": "sha512-DPgxtHuJwBORpqRkPXzzOT+uoPRVJmaN7LR+pmeL6DQM90kj6G6GFUH1i/YpRH8NbML8ZGEDwB9f9u4UwD2pzg==",
       "dev": true
     },
+    "@dotcom-reliability-kit/log-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.3.0.tgz",
+      "integrity": "sha512-3VjGttJoMcurPJO2iL5Cx42xz3PiSSfzXLQjPa0rHqPXKiPdZAsIc3LyJjtUNaU8pav60RUtj1pUpeEy596b6Q==",
+      "requires": {
+        "@dotcom-reliability-kit/serialize-error": "^1.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^1.0.0",
+        "@financial-times/n-logger": "^10.2.0"
+      }
+    },
+    "@dotcom-reliability-kit/serialize-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.0.0.tgz",
+      "integrity": "sha512-ROU7khyWTAIgQf3IzmLwjF5K5CT/pctzxMEr6gG2TmL2L4ahsjxGjq0kt6J8n87lLTAJWy+bu+JpC7c0MJJP1g=="
+    },
+    "@dotcom-reliability-kit/serialize-request": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.0.0.tgz",
+      "integrity": "sha512-1g1LteXQbBQfBZj/bekRIbuREGOKaehXJG3oI7779vYhh7X3f5ohGSjJww1GyPclT9dNkelno4MHDQaJOWngqA=="
+    },
     "@financial-times/eslint-config-next": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@financial-times/eslint-config-next/-/eslint-config-next-3.0.0.tgz",
@@ -14241,10 +14293,11 @@
       }
     },
     "@financial-times/n-raven": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.2.0.tgz",
-      "integrity": "sha512-GJSrqCvlSAtd8Zqolo2UAefjxiNKwIhbaPlBghCtHa9XG2KiVF6QeBLVf3iObKLuxuk4BgIRP4Ec/so2c8vD2g==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
+      "integrity": "sha512-UnybNv9iriGO1PxAffIUyuU9rRsb788mt12YVBbnawHdCeqPEx2TVqSnMkF6wSM5BLosWh4tB4GmwJgbPErZnw==",
       "requires": {
+        "@dotcom-reliability-kit/log-error": "^1.3.0",
         "@financial-times/n-logger": "^10.2.0",
         "raven": "^2.3.0"
       }
@@ -20176,12 +20229,11 @@
       }
     },
     "n-health": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-6.3.0.tgz",
-      "integrity": "sha512-8OQBADNuDl8aCtzN5ABT5iR0Qp945+l/NWpGUf/aLtbmqngrNnlSFv1KVvhKIAHFMC0/z5R71K5toOrereQg/A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.0.tgz",
+      "integrity": "sha512-cr3ooRtMyx0YVy9Gl8MDJXoPZ9nTkxmyngLYyjQVjzN0mLeSI37TvjC+CviWyfAJzBL/rzGgvNIhyU0IXESPww==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.2.0",
         "aws-sdk": "^2.6.10",
         "fetchres": "^1.5.1",
         "moment": "^2.29.4",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "@financial-times/n-flags-client": "^11.1.0",
     "@financial-times/n-logger": "^10.2.0",
-    "@financial-times/n-raven": "^6.2.0",
+    "@financial-times/n-raven": "^6.3.0",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^6.3.0",
+    "n-health": "^7.0.0",
     "next-metrics": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This will result in a breaking change, because n-health v7.0.0 removes
some Splunk logs which teams may be relying on to debug. Nothing changes
in the n-express JavaScript API and so it should be an easy major bump
to perform.

Resolves [FTDCS-254](https://financialtimes.atlassian.net/browse/FTDCS-254).