### PR TITLE
Upgrade n-health ^7.0.0 -> ^7.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^7.0.0",
+        "n-health": "^7.0.1",
         "next-metrics": "^7.1.0",
         "semver": "^7.3.7"
       },
@@ -5145,9 +5145,9 @@
       }
     },
     "node_modules/n-health": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.0.tgz",
-      "integrity": "sha512-cr3ooRtMyx0YVy9Gl8MDJXoPZ9nTkxmyngLYyjQVjzN0mLeSI37TvjC+CviWyfAJzBL/rzGgvNIhyU0IXESPww==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.1.tgz",
+      "integrity": "sha512-Am4C2Ey3oMKR4Wsa02IyHKJk7qZ9jn3aidsmUGqUE3Y8yXDLu3yTAOOhII4bdka8atEMTXBUHefBweNdpR2ubg==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12632,9 +12632,9 @@
       }
     },
     "n-health": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.0.tgz",
-      "integrity": "sha512-cr3ooRtMyx0YVy9Gl8MDJXoPZ9nTkxmyngLYyjQVjzN0mLeSI37TvjC+CviWyfAJzBL/rzGgvNIhyU0IXESPww==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.1.tgz",
+      "integrity": "sha512-Am4C2Ey3oMKR4Wsa02IyHKJk7qZ9jn3aidsmUGqUE3Y8yXDLu3yTAOOhII4bdka8atEMTXBUHefBweNdpR2ubg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "aws-sdk": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^7.0.0",
+    "n-health": "^7.0.1",
     "next-metrics": "^7.1.0",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
Consumes a minimum `n-health` version of [v7.0.1](https://github.com/Financial-Times/n-health/releases/tag/v7.0.1) so that we can state this as a minimum version requirement as part of the [Migrating an app to Heroku log drains](https://financialtimes.atlassian.net/wiki/spaces/DS/pages/7883555001/Migrating+an+app+to+Heroku+log+drains) guide.

### Release version
Like the corresponding `n-health` release version, this should also be a patch release.