### PR TITLE
update to next-metrics 7.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^7.0.1",
-        "next-metrics": "^7.2.1",
+        "next-metrics": "^7.3.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5183,9 +5183,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.2.1.tgz",
-      "integrity": "sha512-x7DVacIuPZqBZP3zvuwX829RIzywlc7mkBZ9iff9itfj0dAINCy+oj/fqrxw+CDOrwEiva9TE8cJGL/3+qjn5w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.3.0.tgz",
+      "integrity": "sha512-GOwish2AMdELgHuuI/6V6yl9IvW+kPALdoRY1UKxOT4+vdJTfzrNl0Q6u0ESwSBlg5UKVIp6zN3uqK7bnT3uSg==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12662,9 +12662,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.2.1.tgz",
-      "integrity": "sha512-x7DVacIuPZqBZP3zvuwX829RIzywlc7mkBZ9iff9itfj0dAINCy+oj/fqrxw+CDOrwEiva9TE8cJGL/3+qjn5w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.3.0.tgz",
+      "integrity": "sha512-GOwish2AMdELgHuuI/6V6yl9IvW+kPALdoRY1UKxOT4+vdJTfzrNl0Q6u0ESwSBlg5UKVIp6zN3uqK7bnT3uSg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^7.0.1",
-    "next-metrics": "^7.2.1",
+    "next-metrics": "^7.3.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Update next metrics to be able to register correctly the requests done to api.ft.com/dotcom-pages

[See next-metrics PR](https://github.com/Financial-Times/next-metrics/pull/478)