### PR TITLE
Upgrade n-health ^7.0.1 -> ^7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^7.0.1",
+        "n-health": "^7.0.2",
         "next-metrics": "^7.3.0",
         "semver": "^7.3.7"
       },
@@ -5145,9 +5145,9 @@
       }
     },
     "node_modules/n-health": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.1.tgz",
-      "integrity": "sha512-Am4C2Ey3oMKR4Wsa02IyHKJk7qZ9jn3aidsmUGqUE3Y8yXDLu3yTAOOhII4bdka8atEMTXBUHefBweNdpR2ubg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.2.tgz",
+      "integrity": "sha512-In9b4f5ERGNFsK/4GwiP2JwYOS0+sry/9N7KCMae2PzR1bNeoD/bmMFIA3fIRqoWGD+yGJH95kgT5CdIS/5JBg==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12632,9 +12632,9 @@
       }
     },
     "n-health": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.1.tgz",
-      "integrity": "sha512-Am4C2Ey3oMKR4Wsa02IyHKJk7qZ9jn3aidsmUGqUE3Y8yXDLu3yTAOOhII4bdka8atEMTXBUHefBweNdpR2ubg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.2.tgz",
+      "integrity": "sha512-In9b4f5ERGNFsK/4GwiP2JwYOS0+sry/9N7KCMae2PzR1bNeoD/bmMFIA3fIRqoWGD+yGJH95kgT5CdIS/5JBg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "aws-sdk": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^7.0.1",
+    "n-health": "^7.0.2",
     "next-metrics": "^7.3.0",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
This PR upgrades the `n-health` dependency from ^7.0.1 -> ^[7.0.2](https://github.com/Financial-Times/n-health/releases/tag/v7.0.2) and will enable the consumption of the change applied in this PR: https://github.com/Financial-Times/n-health/pull/203.