### PR TITLE
Reduce our Heroku API usage in local development

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -48,10 +48,15 @@ module.exports = (app, options, meta) => {
 
 	// See https://github.com/Financial-Times/n-logger#loggers for information on
 	// the log drain migration. We only want to introduce the log drain check if
-	// the app is set up to use log drains. This conditional will be removed once
-	// the log drain migration is complete but it's required for now to reduce
-	// alert spam (see https://financialtimes.atlassian.net/browse/FTDCS-233)
-	if (process.env.MIGRATE_TO_HEROKU_LOG_DRAINS) {
+	// the app is set up to use log drains. The `MIGRATE_TO_HEROKU_LOG_DRAINS`
+	// part of this condition will be removed once the log drain migration is
+	// complete but it's required for now to reduce alert spam
+	// (see https://financialtimes.atlassian.net/browse/FTDCS-233).
+	//
+	// We also only add this check if we're running in production. This is
+	// because we don't want apps running in local development to use up the rate
+	// limit for our shared Heroku API key.
+	if (process.env.NODE_ENV === 'production' && process.env.MIGRATE_TO_HEROKU_LOG_DRAINS) {
 		defaultChecks.push(herokuLogDrainCheck());
 	}
 


### PR DESCRIPTION
Right now every time an app is restarted it will fetch the app's log
drain information using the Heroku API. This is only really needed in
production, and we don't want people running our apps on their local
machines to use up more of our rate limit than necessary.

This also means that Heroku review apps won't make API requests as
their `NODE_ENV` environment variable is set to `branch`.