### PR TITLE
Upgrade n-flags-client ^11.1.0 -> ^12.0.0; n-health ^7.0.2 -> ^8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@financial-times/n-flags-client": "^11.1.0",
+        "@financial-times/n-flags-client": "^12.0.0",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^7.0.2",
+        "n-health": "^8.0.0",
         "next-metrics": "^7.3.0",
         "semver": "^7.3.7"
       },
@@ -460,13 +460,13 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-11.1.0.tgz",
-      "integrity": "sha512-eEUEvft3YOZYcpO4rq58qj7+1KKRhwv6gM7BW/3Lv6rvamihqdP12FddzZgN9xogRvzK7XxDLIWH0wufc8UpLA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.0.tgz",
+      "integrity": "sha512-ZnTnwHMG8e9L9ZGzj6aPrS+7B3BrNjxBcQZ9A2ErukitLEy4jE68XxFYQfRLYMUI7tzE3WE47wS1TVI+YuEnuQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
-        "n-eager-fetch": "^5.1.0",
+        "n-eager-fetch": "^6.0.0",
         "vary": "^1.1.2"
       },
       "engines": {
@@ -2163,6 +2163,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -2171,6 +2172,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -4018,6 +4020,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5121,13 +5124,13 @@
       "dev": true
     },
     "node_modules/n-eager-fetch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-5.1.0.tgz",
-      "integrity": "sha512-jMUo/8InLfQN9PaPmwzUHR41RljALWKuixgi6M1CFc3x5oAztB31KMnYJhbDZ6wVXBeN3mihcGRY6HHklCKrCw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-6.0.0.tgz",
+      "integrity": "sha512-Z/mMwoi5/ylChZzgBhBxQvCx34IazSBcxUYPSzWdoF4KAo6x4+TH2Qe1IFgagaVAyzbDTS1v2XxMptaN3b4pwg==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
-        "isomorphic-fetch": "^2.1.1",
+        "isomorphic-fetch": "^3.0.0",
         "npm-prepublish": "^1.2.2"
       },
       "engines": {
@@ -5135,19 +5138,10 @@
         "npm": "7.x || 8.x"
       }
     },
-    "node_modules/n-eager-fetch/node_modules/isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-      "dependencies": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "node_modules/n-health": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.2.tgz",
-      "integrity": "sha512-In9b4f5ERGNFsK/4GwiP2JwYOS0+sry/9N7KCMae2PzR1bNeoD/bmMFIA3fIRqoWGD+yGJH95kgT5CdIS/5JBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.0.tgz",
+      "integrity": "sha512-plv6AD+9TG/YjcL7Kt096+RqNDa6vMVeC1/4zmcw5qrp02BJmtXsxIAXQ6Lc6g7Vs4TJNJyaM92M+dSC35YXmg==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -5155,11 +5149,30 @@
         "fetchres": "^1.5.1",
         "moment": "^2.29.4",
         "ms": "^2.0.0",
-        "node-fetch": "^1.5.1"
+        "node-fetch": "^2.6.7"
       },
       "engines": {
         "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/n-health/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/natural-compare": {
@@ -5254,6 +5267,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
@@ -9014,12 +9028,12 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-11.1.0.tgz",
-      "integrity": "sha512-eEUEvft3YOZYcpO4rq58qj7+1KKRhwv6gM7BW/3Lv6rvamihqdP12FddzZgN9xogRvzK7XxDLIWH0wufc8UpLA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.0.tgz",
+      "integrity": "sha512-ZnTnwHMG8e9L9ZGzj6aPrS+7B3BrNjxBcQZ9A2ErukitLEy4jE68XxFYQfRLYMUI7tzE3WE47wS1TVI+YuEnuQ==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
-        "n-eager-fetch": "^5.1.0",
+        "n-eager-fetch": "^6.0.0",
         "vary": "^1.1.2"
       }
     },
@@ -10343,6 +10357,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
       "requires": {
         "iconv-lite": "^0.6.2"
       },
@@ -10351,6 +10366,7 @@
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
           "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "devOptional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
@@ -11754,7 +11770,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.7",
@@ -12611,37 +12628,36 @@
       "dev": true
     },
     "n-eager-fetch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-5.1.0.tgz",
-      "integrity": "sha512-jMUo/8InLfQN9PaPmwzUHR41RljALWKuixgi6M1CFc3x5oAztB31KMnYJhbDZ6wVXBeN3mihcGRY6HHklCKrCw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/n-eager-fetch/-/n-eager-fetch-6.0.0.tgz",
+      "integrity": "sha512-Z/mMwoi5/ylChZzgBhBxQvCx34IazSBcxUYPSzWdoF4KAo6x4+TH2Qe1IFgagaVAyzbDTS1v2XxMptaN3b4pwg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
-        "isomorphic-fetch": "^2.1.1",
+        "isomorphic-fetch": "^3.0.0",
         "npm-prepublish": "^1.2.2"
-      },
-      "dependencies": {
-        "isomorphic-fetch": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-          "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-          "requires": {
-            "node-fetch": "^1.0.1",
-            "whatwg-fetch": ">=0.10.0"
-          }
-        }
       }
     },
     "n-health": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-7.0.2.tgz",
-      "integrity": "sha512-In9b4f5ERGNFsK/4GwiP2JwYOS0+sry/9N7KCMae2PzR1bNeoD/bmMFIA3fIRqoWGD+yGJH95kgT5CdIS/5JBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.0.tgz",
+      "integrity": "sha512-plv6AD+9TG/YjcL7Kt096+RqNDa6vMVeC1/4zmcw5qrp02BJmtXsxIAXQ6Lc6g7Vs4TJNJyaM92M+dSC35YXmg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "aws-sdk": "^2.6.10",
         "fetchres": "^1.5.1",
         "moment": "^2.29.4",
         "ms": "^2.0.0",
-        "node-fetch": "^1.5.1"
+        "node-fetch": "^2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "natural-compare": {
@@ -12730,6 +12746,7 @@
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "dependencies": {
-    "@financial-times/n-flags-client": "^11.1.0",
+    "@financial-times/n-flags-client": "^12.0.0",
     "@financial-times/n-logger": "^10.2.0",
     "@financial-times/n-raven": "^6.3.0",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^7.0.2",
+    "n-health": "^8.0.0",
     "next-metrics": "^7.3.0",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
This PR is in relation to https://github.com/Financial-Times/next-preflight/pull/645, which resulted in `next-preflight` consuming a mixture of `isomorphic-fetch` v2 (which consumes `node-fetch` v1) and v3 (which consumes `node-fetch` v2).

The working assumption is that this mixture of `node-fetch` versions had been present before now but that the specific composition and ordering of dependencies meant that an instance of `node-fetch` v1 was always identified first and consequently the version that was employed by the code but that the changes in the above-mentioned PR meant that `node-fetch` v2 was the version employed by the code and that `next-preflight` had not yet been updated to accommodate any major breaking changes.

As a result, this caused [`next-preflight/server/tasks/next/consent.js` l.46](https://github.com/Financial-Times/next-preflight/blob/main/server/tasks/next/consent.js#L46) to throw:

`TypeError: Cannot convert undefined or null to object`

See Slack incident channel **#inc-1750-my-account-page-is-missing-tabs** for more details.

This error manifested itself in the FT.com UI by removing navigation in some pages (first observed on https://www.ft.com/myaccount/personal-details) owing to `next-navigation-api` returning 404 errors (a side effect we are still diagnosing).

This PR upgrades this package's:
- `n-flags-client` version to v12 (which in turn consumes `n-eager-fetch` v6, which in turn consumes `isomorphic-fetch` v3, which in turn consumes `node-fetch` v2)
- `n-health` version to v7 (which in turn consumes `node-fetch` v2)

These are steps to creating the availability of all packages with a `node-fetch` dependency or sub-dependency consumed by `next-preflight` to guarantee that `node-fetch` v2 will be the version employed by the code.

### Release
Given how the mixture of `node-fetch` versions can affect an app as demonstrated in the above incident, I propose issuing this change as a **major** release so that consumers are more conscious of the change they are making.

### References
- [GitHub: node-fetch / node-fetch - Upgrade to node-fetch v2.x](https://github.com/node-fetch/node-fetch/blob/main/docs/v2-UPGRADE-GUIDE.md)