### PR TITLE
ACC-1932 Bump up next-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^8.0.0",
-        "next-metrics": "^7.3.0",
+        "next-metrics": "^7.4.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5196,9 +5196,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.3.0.tgz",
-      "integrity": "sha512-GOwish2AMdELgHuuI/6V6yl9IvW+kPALdoRY1UKxOT4+vdJTfzrNl0Q6u0ESwSBlg5UKVIp6zN3uqK7bnT3uSg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.4.0.tgz",
+      "integrity": "sha512-fPyA9i+j8poVLkpANDrmpElbdzg2P1lUQDPt+MqsiL/l4BcmZTtskjp5OIYcQdcvaVAazK575v5jXvrsSW+rfg==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12678,9 +12678,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.3.0.tgz",
-      "integrity": "sha512-GOwish2AMdELgHuuI/6V6yl9IvW+kPALdoRY1UKxOT4+vdJTfzrNl0Q6u0ESwSBlg5UKVIp6zN3uqK7bnT3uSg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.4.0.tgz",
+      "integrity": "sha512-fPyA9i+j8poVLkpANDrmpElbdzg2P1lUQDPt+MqsiL/l4BcmZTtskjp5OIYcQdcvaVAazK575v5jXvrsSW+rfg==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^8.0.0",
-    "next-metrics": "^7.3.0",
+    "next-metrics": "^7.4.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumping up next-metrics to v7.4.0 which includes the graphql gateway endpoints as allowed services.

related PR from `next-metrics`: https://github.com/Financial-Times/next-metrics/pull/479 

[TICKET](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1932)