### PR TITLE
Require Heroku log drains in all n-express apps

### DIFF
--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -46,17 +46,13 @@ module.exports = (app, options, meta) => {
 		supportedNodeJsVersionCheck(meta.name)
 	];
 
-	// See https://github.com/Financial-Times/n-logger#loggers for information on
-	// the log drain migration. We only want to introduce the log drain check if
-	// the app is set up to use log drains. The `MIGRATE_TO_HEROKU_LOG_DRAINS`
-	// part of this condition will be removed once the log drain migration is
-	// complete but it's required for now to reduce alert spam
-	// (see https://financialtimes.atlassian.net/browse/FTDCS-233).
+	// We require our Express Heroku apps to have a log drain configured, so that
+	// all logs are available in Splunk.
 	//
-	// We also only add this check if we're running in production. This is
-	// because we don't want apps running in local development to use up the rate
-	// limit for our shared Heroku API key.
-	if (process.env.NODE_ENV === 'production' && process.env.MIGRATE_TO_HEROKU_LOG_DRAINS) {
+	// We only add this check if we're running in production. This is because we
+	// don't want apps running in local development to use up the rate limit for
+	// our shared Heroku API key.
+	if (process.env.NODE_ENV === 'production') {
 		defaultChecks.push(herokuLogDrainCheck());
 	}
 


### PR DESCRIPTION
Now that we have a timeline for completing the log drain migration (30th June 2023), we want to start failing health checks for apps which don't have them configured yet. The condition based on the migration environment variable was always intended to be removed ([FTDCS-233](https://financialtimes.atlassian.net/browse/FTDCS-233)) and now feels like a good time.

**Outstanding question:** what kind of release should this be? Minor?

Resolves [FTDCS-316](https://financialtimes.atlassian.net/browse/FTDCS-316).