### PR TITLE
Upgrade n-health ^8.0.0 -> ^8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^8.0.0",
+        "n-health": "^8.0.1",
         "next-metrics": "^7.4.0",
         "semver": "^7.3.7"
       },
@@ -5139,9 +5139,9 @@
       }
     },
     "node_modules/n-health": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.0.tgz",
-      "integrity": "sha512-plv6AD+9TG/YjcL7Kt096+RqNDa6vMVeC1/4zmcw5qrp02BJmtXsxIAXQ6Lc6g7Vs4TJNJyaM92M+dSC35YXmg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.1.tgz",
+      "integrity": "sha512-9VMSIrh6h9uB6Zaefhz7qxVFQ+Y6jV6QNVrvkGe1oIRY6eWZBgIRZvidsOjhKaLiNH7c+9LH+o+/N+2scPNUAw==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12638,9 +12638,9 @@
       }
     },
     "n-health": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.0.tgz",
-      "integrity": "sha512-plv6AD+9TG/YjcL7Kt096+RqNDa6vMVeC1/4zmcw5qrp02BJmtXsxIAXQ6Lc6g7Vs4TJNJyaM92M+dSC35YXmg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.1.tgz",
+      "integrity": "sha512-9VMSIrh6h9uB6Zaefhz7qxVFQ+Y6jV6QNVrvkGe1oIRY6eWZBgIRZvidsOjhKaLiNH7c+9LH+o+/N+2scPNUAw==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "aws-sdk": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^8.0.0",
+    "n-health": "^8.0.1",
     "next-metrics": "^7.4.0",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
This PR upgrades this app's dependency of `n-health` to ensure that it consumes the changes made in this PR: https://github.com/Financial-Times/n-health/pull/205 ("Increase interval between Heroku log drain health checks").

We hope that this will mitigate the Heroku API auth token rate limit issues we are currently experiencing, because it is the Heroku log drain health check that is experiencing this issue most widely, and (as per the `n-health` PR) we feel this health check can afford to be run less frequently.