### PR TITLE
Honour the error status code

### DIFF
--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -51,9 +51,19 @@ module.exports = class InstrumentListen {
 			// Optional fallthrough error handler
 			// eslint-disable-next-line no-unused-vars
 			this.app.use((err, req, res, next) => {
+				let statusCode = err.statusCode || err.status || 500;
+
+				// There's clearly an error, so if the error has a status
+				// code of less than `400` we should default to `500` to
+				// ensure bad error handling doesn't send false positive
+				// status codes
+				if (statusCode < 400) {
+					statusCode = 500;
+				}
+
 				// The error id is attached to `res.sentry` to be returned
 				// and optionally displayed to the user for support.
-				res.statusCode = 500;
+				res.statusCode = statusCode;
 				res.end(res.sentry + '\n');
 			});
 


### PR DESCRIPTION
We have useful information across all our apps which we're just ignoring. We use HTTP errors extensively which set either a `status` or `statusCode` property and there's no way for these errors to actually impact the status code which is sent to the end-user. This means that our Fastly logging isn't particularly useful, e.g. we can't say:

> Hmm, Fastly is logging a lot of `502` errors, I wonder which upstream
> service is causing us issues.

I don't think that this was ever given lots of thought as it was added 5 years ago without much of a description: 3f0f2af

Does anyone object to us honouring an error's status code if it has one?

## Why now?

This has been annoying me for _ages_, but I think I finally have a legit reason to add it in. [I'm working on surfacing proper error codes for next-topic-tracker-api](https://github.com/Financial-Times/next-topic-tracker-api/pull/165), which will now correctly throw errors with `502` and `504` status codes. Right now these will never appear in Fastly because of this n-express code, and we need them to appear in Fastly so that we can adjust our monitoring.

---

Relates to [CPREL-348](https://financialtimes.atlassian.net/browse/CPREL-348).