### PR TITLE
Guard against bad error status codes

### DIFF
--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -51,19 +51,22 @@ module.exports = class InstrumentListen {
 			// Optional fallthrough error handler
 			// eslint-disable-next-line no-unused-vars
 			this.app.use((err, req, res, next) => {
-				let statusCode = err.statusCode || err.status || 500;
+				let statusCode = parseInt(err.statusCode || err.status || 500, 10);
 
 				// There's clearly an error, so if the error has a status
 				// code of less than `400` we should default to `500` to
 				// ensure bad error handling doesn't send false positive
-				// status codes
-				if (statusCode < 400) {
-					statusCode = 500;
-				}
+				// status codes. We also check that the status code is
+				// a valid number.
+				const isValidErrorStatus = (
+					!Number.isNaN(statusCode) && // Possible if `error.status` is something unexpected, like an object
+					statusCode >= 400 &&
+					statusCode <= 599
+				);
 
 				// The error id is attached to `res.sentry` to be returned
 				// and optionally displayed to the user for support.
-				res.statusCode = statusCode;
+				res.statusCode = isValidErrorStatus ? statusCode : 500;
 				res.end(res.sentry + '\n');
 			});
 


### PR DESCRIPTION
Thanks to @jkerr321 for raising this, it's totally possible for these error statuses to be something unexpected. This PR guards against any case where the status code cannot be converted to a number or isn't a valid HTTP error status code.