### PR TITLE
Add a withSentry option to allow disabling n-raven

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 - `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality. Backend authentication is required for applications serving traffic that should only come via the Fastly -> Preflight -> Router request routing. An example of why is the Next Article application, if this didn't have backend authentication enabled you would be able to view articles via the heroku application url as it wouldn't be protected by barriers which are handled within Fastly and Preflight.
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
 - `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`
+- `withSentry` - adds [Sentry](https://sentry.io/) error handling, both as an Express error handler and an uncaught exception handler. Defaults to `true`
 - `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -42,6 +42,7 @@ export interface AppOptions extends AppMeta {
 	withConsent: boolean;
 	withBackendAuthentication: boolean;
 	withFlags: boolean;
+	withSentry?: boolean;
 	withServiceMetrics: boolean;
 }
 


### PR DESCRIPTION
This option is the first step towards us being able to provide an alternative for Sentry, or at least unpick our Sentry implementation from n-express. This is needed for us to even properly experiment in this space, we'd like to be able to trial disabling Sentry on some of our low-traffic internal apps (e.g. Houston) and it's currently not possible at all.

Notes on my choices:

  - Because importing the n-raven module has side-effects (i.e. just requiring it will register uncaught exception handlers), we had to move the `require` statements into conditionals within the n-express setup code. This is a little ugly. We could possibly abstract this into a new file within n-express if you really hate this.

  - I opted for a `withSentry` option defaulting to `true` as this is consistent with the other n-express options.

  - In production, the default error handler outputs the Sentry error ID if it's enabled and we no longer have that data if the `withSentry` option is `true`. I decided a reasonable alternative which doesn't give away any important error information would be to send the status code and status message associated with the error.

  - For now (at the request of @joelcarr) I added a warning message if you set the `withSentry` option to `false`. This is to highlight that it's still an experimental option and so that we in the Reliability team can keep track of any apps which have disabled Sentry prematurely.