### PR TITLE
Upgrade next-metrics ^7.4.0 -> ^7.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^8.0.1",
-    "next-metrics": "^7.4.0",
+    "next-metrics": "^7.4.1",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades its `next-metrics` package dependency to consume the current latest version:

[v7.4.1: Remove references to unused next-navigation S3 buckets](https://github.com/Financial-Times/next-metrics/releases/tag/v7.4.1)