### PR TITLE
upgrade next-metrics to 7.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^8.0.1",
-        "next-metrics": "^7.6.0",
+        "next-metrics": "^7.6.1",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5196,9 +5196,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.6.0.tgz",
-      "integrity": "sha512-f2wRvxR0fDTQxNIhRiNjNEul5gqmkWmEcl+pm8/fLzFxvPmK4fQjlInWEqnSVWADGe8RR+1bmLu1OhbJFHBdLA==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.6.1.tgz",
+      "integrity": "sha512-KhXLEU4RH4tIHAXKMYGt2dTB2inQWe2Omgn/lDwY5rtrjpqeh1q00E2a6VZf/eqgmfG0P1URyrxDL2kv9L0QXw==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12678,9 +12678,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.6.0.tgz",
-      "integrity": "sha512-f2wRvxR0fDTQxNIhRiNjNEul5gqmkWmEcl+pm8/fLzFxvPmK4fQjlInWEqnSVWADGe8RR+1bmLu1OhbJFHBdLA==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-7.6.1.tgz",
+      "integrity": "sha512-KhXLEU4RH4tIHAXKMYGt2dTB2inQWe2Omgn/lDwY5rtrjpqeh1q00E2a6VZf/eqgmfG0P1URyrxDL2kv9L0QXw==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^8.0.1",
-    "next-metrics": "^7.6.0",
+    "next-metrics": "^7.6.1",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Upgrade next-metrics to [7.6.1](https://github.com/Financial-Times/next-metrics/releases/tag/v7.6.1) which registers the `spark-lists.ft.com` service