### PR TITLE
Upgrade n-health ^8.0.1 -> ^8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
-        "n-health": "^8.0.1",
+        "n-health": "^8.0.2",
         "next-metrics": "^7.6.1",
         "semver": "^7.3.7"
       },
@@ -5139,9 +5139,9 @@
       }
     },
     "node_modules/n-health": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.1.tgz",
-      "integrity": "sha512-9VMSIrh6h9uB6Zaefhz7qxVFQ+Y6jV6QNVrvkGe1oIRY6eWZBgIRZvidsOjhKaLiNH7c+9LH+o+/N+2scPNUAw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.2.tgz",
+      "integrity": "sha512-bjRWxcPDfjx69fqoFiuePntLudN0Mi6ihWdsziLzLZtHU7eHokrOKvgoq+DKosak4jF9HsTRCfYJ+a6ExyEgTQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12638,9 +12638,9 @@
       }
     },
     "n-health": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.1.tgz",
-      "integrity": "sha512-9VMSIrh6h9uB6Zaefhz7qxVFQ+Y6jV6QNVrvkGe1oIRY6eWZBgIRZvidsOjhKaLiNH7c+9LH+o+/N+2scPNUAw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/n-health/-/n-health-8.0.2.tgz",
+      "integrity": "sha512-bjRWxcPDfjx69fqoFiuePntLudN0Mi6ihWdsziLzLZtHU7eHokrOKvgoq+DKosak4jF9HsTRCfYJ+a6ExyEgTQ==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "aws-sdk": "^2.6.10",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "denodeify": "^1.2.1",
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
-    "n-health": "^8.0.1",
+    "n-health": "^8.0.2",
     "next-metrics": "^7.6.1",
     "semver": "^7.3.7"
   },


### PR DESCRIPTION
This PR upgrades this app's dependency of `n-health` to ensure that it consumes the changes made in this PR: https://github.com/Financial-Times/n-health/pull/270 ("Remove Heroku log drain healthcheck" - the test will instead live in `next-health`).

We hope that this will mitigate the Heroku API auth token rate limit issues we are currently experiencing.

A previous PR https://github.com/Financial-Times/n-express/pull/730 upgraded the `n-health` dependency from ^8.0.0 -> ^8.0.1 to consume the changes in this PR https://github.com/Financial-Times/n-health/pull/205, though that healthcheck only increased the interval between the check being conducted, which still resulted in the issue described in this blog post: [How The Reliability Team Broke Deploys For Everyone](https://financialtimes.atlassian.net/wiki/spaces/DS/blog/2022/09/23/7914422524/How+The+Reliability+Team+Broke+Deploys+For+Everyone) (key takeaway: "We’re hitting the Heroku API 112 times instead of twice").

Any apps consuming [v26.1.1](https://github.com/Financial-Times/n-express/releases/tag/v26.1.1) of this package could potentially already be consuming v8.0.2 of `n-health` owing to the use of the caret in the version number, but the change applied in this PR will mean that any apps consuming the next release of this package will definitely be using the version of `n-health` that removes the Heroku log drain healthcheck.