### PR TITLE
Correctly handle ERR_STREAM_WRITE_AFTER_END errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
         "@financial-times/n-flags-client": "^12.0.0",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
@@ -382,35 +384,45 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
+      "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA==",
+      "engines": {
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
+      }
+    },
     "node_modules/@dotcom-reliability-kit/log-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.3.0.tgz",
-      "integrity": "sha512-3VjGttJoMcurPJO2iL5Cx42xz3PiSSfzXLQjPa0rHqPXKiPdZAsIc3LyJjtUNaU8pav60RUtj1pUpeEy596b6Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.5.0.tgz",
+      "integrity": "sha512-cpAe0g3BfwgVC36vr++HGVKOC+ad9wc2xY4H53fFqPTx6v+aeIhp38P1umDWlLShDn+WfSK6Wx1WcBqkL2CC+g==",
       "dependencies": {
-        "@dotcom-reliability-kit/serialize-error": "^1.0.0",
-        "@dotcom-reliability-kit/serialize-request": "^1.0.0",
-        "@financial-times/n-logger": "^10.2.0"
+        "@dotcom-reliability-kit/app-info": "^1.0.3",
+        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
+        "@financial-times/n-logger": "^10.3.1"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/serialize-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.0.0.tgz",
-      "integrity": "sha512-ROU7khyWTAIgQf3IzmLwjF5K5CT/pctzxMEr6gG2TmL2L4ahsjxGjq0kt6J8n87lLTAJWy+bu+JpC7c0MJJP1g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.1.4.tgz",
+      "integrity": "sha512-5pi/4exUhAP6PTaLzl+3H4Q2lD61C7mZOGWpVWQ5lQmJUq2ilUFo+r3tlfv1GY6sUTmlSUGRkkR+YC3GeJSfVA==",
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/serialize-request": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.0.0.tgz",
-      "integrity": "sha512-1g1LteXQbBQfBZj/bekRIbuREGOKaehXJG3oI7779vYhh7X3f5ohGSjJww1GyPclT9dNkelno4MHDQaJOWngqA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.1.0.tgz",
+      "integrity": "sha512-Dfw2TKnb977dtt+8aELOsYcujaqf2JwoeMzDxpfj6js875KcPSw3Rl11sjlf22hEHtpVDfTsrZATgihhBHj8qw==",
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -501,17 +513,17 @@
       }
     },
     "node_modules/@financial-times/n-logger": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
-      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
+      "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
       "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
-        "node-fetch": "^2.6.0",
-        "winston": "^2.4.0"
+        "node-fetch": "^2.6.7",
+        "winston": "^2.4.6"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -8963,25 +8975,31 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dotcom-reliability-kit/app-info": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
+      "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA=="
+    },
     "@dotcom-reliability-kit/log-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.3.0.tgz",
-      "integrity": "sha512-3VjGttJoMcurPJO2iL5Cx42xz3PiSSfzXLQjPa0rHqPXKiPdZAsIc3LyJjtUNaU8pav60RUtj1pUpeEy596b6Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.5.0.tgz",
+      "integrity": "sha512-cpAe0g3BfwgVC36vr++HGVKOC+ad9wc2xY4H53fFqPTx6v+aeIhp38P1umDWlLShDn+WfSK6Wx1WcBqkL2CC+g==",
       "requires": {
-        "@dotcom-reliability-kit/serialize-error": "^1.0.0",
-        "@dotcom-reliability-kit/serialize-request": "^1.0.0",
-        "@financial-times/n-logger": "^10.2.0"
+        "@dotcom-reliability-kit/app-info": "^1.0.3",
+        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
+        "@financial-times/n-logger": "^10.3.1"
       }
     },
     "@dotcom-reliability-kit/serialize-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.0.0.tgz",
-      "integrity": "sha512-ROU7khyWTAIgQf3IzmLwjF5K5CT/pctzxMEr6gG2TmL2L4ahsjxGjq0kt6J8n87lLTAJWy+bu+JpC7c0MJJP1g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.1.4.tgz",
+      "integrity": "sha512-5pi/4exUhAP6PTaLzl+3H4Q2lD61C7mZOGWpVWQ5lQmJUq2ilUFo+r3tlfv1GY6sUTmlSUGRkkR+YC3GeJSfVA=="
     },
     "@dotcom-reliability-kit/serialize-request": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.0.0.tgz",
-      "integrity": "sha512-1g1LteXQbBQfBZj/bekRIbuREGOKaehXJG3oI7779vYhh7X3f5ohGSjJww1GyPclT9dNkelno4MHDQaJOWngqA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.1.0.tgz",
+      "integrity": "sha512-Dfw2TKnb977dtt+8aELOsYcujaqf2JwoeMzDxpfj6js875KcPSw3Rl11sjlf22hEHtpVDfTsrZATgihhBHj8qw=="
     },
     "@financial-times/eslint-config-next": {
       "version": "3.0.0",
@@ -9060,13 +9078,13 @@
       }
     },
     "@financial-times/n-logger": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
-      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.3.1.tgz",
+      "integrity": "sha512-qOy3Mqp10W8tD1hQiO6iuqDRE89gTdylIoxlkySK2/4RXGp8oUJm4ulpoIJzC2aw7ZDAvt8Yx47Z6osDfCBEvw==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
-        "node-fetch": "^2.6.0",
-        "winston": "^2.4.0"
+        "node-fetch": "^2.6.7",
+        "winston": "^2.4.6"
       },
       "dependencies": {
         "node-fetch": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "dependencies": {
+    "@dotcom-reliability-kit/serialize-error": "^1.1.4",
+    "@dotcom-reliability-kit/serialize-request": "^1.1.0",
     "@financial-times/n-flags-client": "^12.0.0",
     "@financial-times/n-logger": "^10.2.0",
     "@financial-times/n-raven": "^6.3.0",


### PR DESCRIPTION
We got an [app crash alert in the ft-next-support channel today](https://financialtimes.slack.com/archives/C042NBBTM/p1670374854221419) where next-syndication-api was sending a response after one has already been sent. I'm certain we need to do some work in that app too, but the error doesn't have enough detail for me to work out where the response is being written.

The error highlighted that we don't handle this case particularly well - [the Express documentation suggests](https://expressjs.com/en/guide/error-handling.html#the-default-error-handler) that you should always fall back to the default error handler if headers have already been sent to avoid this. I tracked this down to the [finalhandler](https://www.npmjs.com/package/finalhandler) module (which Express uses) and it [correctly terminates the request](https://github.com/pillarjs/finalhandler/blob/5ceb3e3e2482404cb71e9810bd10a422fe748f20/index.js#L128) instead of causing a crash.

I decided to use Reliability Kit's serializers here so that we have the same amount of detail as in our other errors. The main useful thing for debugging next-syndication-api will be having a log of the request that was made so that I can work out which route is erroring.