### PR TITLE
Downgrade error to a warning

### DIFF
--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -85,7 +85,7 @@ module.exports = class InstrumentListen {
 				//
 				// This ensures that the app doesn't crash with `ERR_STREAM_WRITE_AFTER_END`
 				if (res.headersSent) {
-					nLogger.error({
+					nLogger.warn({
 						event: 'EXPRESS_ERROR_HANDLER_FAILURE',
 						message: 'The default n-express error handler could not output because the response has already been sent',
 						error: serializeError(err),


### PR DESCRIPTION
Turns out this isn't fixable in next-syndication-api without a complete rewrite of a bunch of middleware. I'm going to leave this guard in place but downgrade the log to a warning instead of an error - in the case of next-syndication they're sending correct error codes and headers etc.