### PR TITLE
bump n-flags-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-flags-client": "^12.0.1",
+        "@financial-times/n-flags-client": "^12.0.2",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.1.tgz",
-      "integrity": "sha512-Sif0lP4/MSku7sFxpxoYSkHMSPZxEPl/CW18p2b+oSL6Lf8nyEWu0B4o0XuYthtinofpz6/2TGrWYmRTZF98vw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.2.tgz",
+      "integrity": "sha512-DnTzygCEykhObkqsD43F/nMf0TtK4GAmeo81yPUhiqKuM36jAx6m3w0tiwAEjPpEwHFtBv3uojlY9ev0a1BVmA==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -6863,6 +6863,7 @@
       "version": "1.981.0",
       "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.981.0.tgz",
       "integrity": "sha512-xCXJ74DBsy7vKRdNRJJ3HVFEOEZ2+9eIdRPrgIBQeFcn3zsFgmGo/dva3EN6im75lwxCgVIdKv00bDnM2wyZTA==",
+      "deprecated": "A medium severity vulnerability was found in the Snyk CLI version you are using. We fixed the vulnerability in version 1.996.0. We recommend updating to the latest version. More details here: https://snyk.co/ue1NS",
       "dev": true,
       "bin": {
         "snyk": "bin/snyk"
@@ -9046,9 +9047,9 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.1.tgz",
-      "integrity": "sha512-Sif0lP4/MSku7sFxpxoYSkHMSPZxEPl/CW18p2b+oSL6Lf8nyEWu0B4o0XuYthtinofpz6/2TGrWYmRTZF98vw==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.2.tgz",
+      "integrity": "sha512-DnTzygCEykhObkqsD43F/nMf0TtK4GAmeo81yPUhiqKuM36jAx6m3w0tiwAEjPpEwHFtBv3uojlY9ev0a1BVmA==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "n-eager-fetch": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@dotcom-reliability-kit/serialize-error": "^1.1.4",
     "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-    "@financial-times/n-flags-client": "^12.0.1",
+    "@financial-times/n-flags-client": "^12.0.2",
     "@financial-times/n-logger": "^10.2.0",
     "@financial-times/n-raven": "^6.3.0",
     "debounce": "^1.1.0",


### PR DESCRIPTION
to pull in https://github.com/Financial-Times/n-flags-client/pull/179 which updates logs to check for headers before calling the header.entries() method