### PR TITLE
Re-add log drain healthcheck via next-health

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@dotcom-reliability-kit/errors": "^1.2.7",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@dotcom-reliability-kit/serialize-request": "^1.1.0",
         "@financial-times/n-flags-client": "^12.0.2",
@@ -131,6 +132,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
       "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA==",
+      "engines": {
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/errors": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-1.2.7.tgz",
+      "integrity": "sha512-P53G0vCEP0AHwavUIZR3C1nCSlmTHLCgrrr8o4sjTlBQpbmiceRzWLTCWYvKluQxzCXTpSiiCenrgjK4ZdoAbQ==",
       "engines": {
         "node": "14.x || 16.x || 18.x",
         "npm": "7.x || 8.x"
@@ -8693,6 +8703,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
       "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA=="
+    },
+    "@dotcom-reliability-kit/errors": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-1.2.7.tgz",
+      "integrity": "sha512-P53G0vCEP0AHwavUIZR3C1nCSlmTHLCgrrr8o4sjTlBQpbmiceRzWLTCWYvKluQxzCXTpSiiCenrgjK4ZdoAbQ=="
     },
     "@dotcom-reliability-kit/log-error": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "dotcom-tool-kit run:local"
   },
   "dependencies": {
+    "@dotcom-reliability-kit/errors": "^1.2.7",
     "@dotcom-reliability-kit/serialize-error": "^1.1.4",
     "@dotcom-reliability-kit/serialize-request": "^1.1.0",
     "@financial-times/n-flags-client": "^12.0.2",

--- a/src/lib/heroku-log-drain-check.js
+++ b/src/lib/heroku-log-drain-check.js
@@ -1,0 +1,55 @@
+/**
+ * @typedef {import("../../typings/n-express").HerokuLogDrainHealthcheckOptions} HerokuLogDrainHealthcheckOptions
+ * @typedef {import("../../typings/n-express").NextHealthLogDrainResponse} NextHealthLogDrainResponse
+ * @typedef {import("../../typings/metrics").Healthcheck} Healthcheck
+ * @typedef {import("../../typings/metrics").TickingMetric} TickingMetric
+ */
+const { UpstreamServiceError } = require('@dotcom-reliability-kit/errors');
+const nHealth = require('n-health');
+
+/**
+ * @param {NextHealthLogDrainResponse} [jsonResponse]
+ * @returns {boolean}
+ */
+const logDrainVerification = (jsonResponse) => {
+	if (!jsonResponse?.status?.hasOwnProperty('ok')) {
+		throw new UpstreamServiceError({
+			code: 'NEXT_HEALTH_LOG_DRAIN_PROXY_ERROR',
+			message: 'Unable to parse log drain response from next-health',
+			relatesToSystems: ['next-health'],
+			jsonResponse
+		});
+	}
+	return jsonResponse.status.ok;
+};
+
+/**
+ * @param {HerokuLogDrainHealthcheckOptions?} [opts]
+ * @returns {Healthcheck & TickingMetric}
+ */
+module.exports = (opts) => {
+	opts = opts || {};
+
+	const region = process.env.REGION === 'US' ? 'us' : 'eu';
+
+	const logDrainStatusUrl = `https://ft-next-health-eu.herokuapp.com/log-drains/${opts.herokuAppId}`;
+
+	return nHealth.runCheck({
+		id: `heroku-log-drain-${region}`,
+		name: `Heroku log drain configured (${region.toUpperCase()})`,
+		type: 'json',
+		severity: 2,
+		businessImpact: 'No user impact. Logs will not be collected in Splunk for this system in the event of the app crashing, making it harder to diagnose the cause.',
+		panicGuide: 'Verify the log drain configuration. Contact #cp-reliability if you need help.',
+		technicalSummary: 'Connects to next-health which reports on the status of log drains.',
+		interval: '1hour',
+		url: logDrainStatusUrl,
+		callback: logDrainVerification,
+		checkResult: {
+			PASSED: 'Log drain is configured correctly.',
+			FAILED: `Log drain configuration is bad. Visit ${logDrainStatusUrl} for details.`,
+			ERRORED: 'Log drain check has errored.',
+			PENDING: 'Log drain check is pending, check back soon.'
+		}
+	});
+};

--- a/test/app/heroku-log-drain-check.test.js
+++ b/test/app/heroku-log-drain-check.test.js
@@ -1,0 +1,51 @@
+const {expect} = require('chai');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+
+const nHealth = {
+	runCheck: sinon.stub().returns('mock-check')
+};
+
+const herokuLogDrainCheck = proxyquire('../../src/lib/heroku-log-drain-check', {
+	'n-health': nHealth
+});
+
+describe('Heroku log drain check', () => {
+	let originalEnv;
+
+	beforeEach(() => {
+		originalEnv = Object.assign({}, process.env);
+		herokuLogDrainCheck();
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('runs a Heroku log drain check', () => {
+		expect(nHealth.runCheck.callCount).to.equal(1);
+		expect(nHealth.runCheck.firstCall.args.length).to.equal(1);
+		expect(nHealth.runCheck.firstCall.args[0].id).to.equal('heroku-log-drain-eu');
+		expect(nHealth.runCheck.firstCall.args[0].type).to.equal('json');
+		expect(nHealth.runCheck.firstCall.args[0].interval).to.equal('1hour');
+	});
+
+	describe('when the `REGION` environment variable is set to "US"', () => {
+
+		beforeEach(() => {
+			nHealth.runCheck.resetHistory();
+			process.env.REGION = 'US';
+			herokuLogDrainCheck();
+		});
+
+		it('suffixes the check ID with "us"', () => {
+			expect(nHealth.runCheck.firstCall.args[0].id).to.equal('heroku-log-drain-us');
+		});
+
+		it('suffixes the check name with "(US)"', () => {
+			expect(nHealth.runCheck.firstCall.args[0].name).to.equal('Heroku log drain configured (US)');
+		});
+
+	});
+
+});

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -53,9 +53,17 @@ export interface ErrorRateHealthcheckOptions {
 }
 
 export interface HerokuLogDrainHealthcheckOptions {
-	severity?: number;
-	herokuAuthToken?: string;
 	herokuAppId?: string;
+}
+
+interface NextHealthLogDrainStatus {
+	ok: boolean;
+	description: String;
+}
+
+export interface NextHealthLogDrainResponse {
+	herokuAppId: string;
+	status: NextHealthLogDrainStatus;
 }
 
 export interface AppContainer {


### PR DESCRIPTION
This check uses a new endpoint on next-health which will proxy the Heroku API and therefore doesn't impact our Heroku API quota too badly.

This healthcheck will roll out to all applications automatically as they upgrade to this version of n-express.

We can deploy next-health to adjust the success/failure criteria of this check instantly.

I attempted to use optional chaining for the jsonResponse callback function but got into a huge mess of n-gage/eslint/eslint-config-next upgrades and couldn't be bothered to fix it.

This commit is a sort-of revert of 19e9ecefc224115cd7592d05cbc83c88e4ad1d04.