### PR TITLE
CircleCi config fix: Remove dependency on node 14 test job for publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ workflows:
           context: npm-publish-token
           requires:
             - tool-kit/test-v16.14
-            - tool-kit/test-v14.19
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
The circle workflow for n-express runs two parallel jobs - a build and test job for Node 16 and a build a test job for Node 14. Each job attaches and persists a workspace. Previously both jobs were required for the publish job to commence, but this causes CircleCi to error because of the duplicate files in the concurrent workspaces:

```
Error applying workspace layer for job 3a818431-dd9d-4663-bf96-769d5da1516f: Concurrent upstream jobs persisted the same file(s)
```

This fix removes the dependency on the node 14 test job for publish to resolve that error.