### PR TITLE
Run tests in and officially support Node.js 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
           name: tool-kit/build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "18.14", "16.19", "14.21" ]
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -53,15 +53,15 @@ workflows:
           name: tool-kit/test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "18.14", "16.19", "14.21" ]
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
       - tool-kit/publish:
-          node-version: 16.14-browsers
+          node-version: 18.14-browsers
           context: npm-publish-token
           requires:
-            - tool-kit/test-v16.14
+            - tool-kit/test-v18.14
           filters:
             branches:
               ignore: /.*/
@@ -87,11 +87,11 @@ workflows:
           name: tool-kit/build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "18.14", "16.19", "14.21" ]
       - tool-kit/test:
           requires:
             - tool-kit/build-v<< matrix.node-version >>
           name: tool-kit/test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "18.14", "16.19", "14.21" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,8 +54,8 @@
         "typescript": "4.3.5"
       },
       "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
+        "node": "14.x || 16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
     "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
   },
   "engines": {
-    "node": "14.x || 16.x",
-    "npm": "7.x || 8.x"
+    "node": "14.x || 16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "config": {},
   "false": {},
   "volta": {
-    "node": "16.14.1",
-    "npm": "7.20.2"
+    "node": "18.14.0",
+    "npm": "9.5.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This makes sure that this library is definitely usable in Node.js 18