### PR TITLE
bump n-flags-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dotcom-reliability-kit/errors": "^1.2.7",
         "@dotcom-reliability-kit/serialize-error": "^1.1.4",
         "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-flags-client": "^12.0.5",
+        "@financial-times/n-flags-client": "^12.0.6",
         "@financial-times/n-logger": "^10.2.0",
         "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
@@ -689,9 +689,9 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.5.tgz",
-      "integrity": "sha512-UkjXM6Hx4+H0mTtsfFvjme22tzo0w1skSBA0XclfW8GEcxeZErzNONzUK6nAYN7/pbM6HhtY/FBT6jY608wSag==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.6.tgz",
+      "integrity": "sha512-AbIWaiu8J5igAIsFAYcVxZgThS0Y2/hJXVEg1e/VLLOD0ou1hzFDlx5HDBvFhinBxpkFIPv1QXPRNqaoJBSyVQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -9150,9 +9150,9 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.5.tgz",
-      "integrity": "sha512-UkjXM6Hx4+H0mTtsfFvjme22tzo0w1skSBA0XclfW8GEcxeZErzNONzUK6nAYN7/pbM6HhtY/FBT6jY608wSag==",
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-12.0.6.tgz",
+      "integrity": "sha512-AbIWaiu8J5igAIsFAYcVxZgThS0Y2/hJXVEg1e/VLLOD0ou1hzFDlx5HDBvFhinBxpkFIPv1QXPRNqaoJBSyVQ==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "n-eager-fetch": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@dotcom-reliability-kit/errors": "^1.2.7",
     "@dotcom-reliability-kit/serialize-error": "^1.1.4",
     "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-    "@financial-times/n-flags-client": "^12.0.5",
+    "@financial-times/n-flags-client": "^12.0.6",
     "@financial-times/n-logger": "^10.2.0",
     "@financial-times/n-raven": "^6.3.0",
     "debounce": "^1.1.0",


### PR DESCRIPTION
to fix unhandled error crash when flags are available.

See https://github.com/Financial-Times/n-flags-client/pull/183