### PR TITLE
DO NOT MERGE switch Renovate config to non-beta version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,5 @@
 {
-  "extends": ["github>financial-times/renovate-config-next-beta"]
+  "extends": [
+    "github>financial-times/renovate-config-next"
+  ]
 }


### PR DESCRIPTION
we're merging renovate-config-next-beta back into renovate-config-next. this hasn't happened yet, but when it does, merge this PR to make sure your renovate config is up to date.