### PR TITLE
Upgrade next-metrics to count SNR Engagement metrics API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^10.0.0",
-        "next-metrics": "^8.0.0",
+        "next-metrics": "^8.0.1",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5690,9 +5690,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-8.0.0.tgz",
-      "integrity": "sha512-DwiRBlpqwKqGGPmJ5XJwzbyoQLsRBkwicn4coTDDp0f14ZJ7k0/C+zf8nK5TwUilYeP7uNvG9TEnAKohu9dtAw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-8.0.1.tgz",
+      "integrity": "sha512-MdIfyylJUgz50Pk77ZYvOg40a7Fn+tjf/X7h6yuCr0wfzcj2WJFt+Us8eIveN3nAC+8b/bah6YW5+Foqf+i0GA==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -13028,9 +13028,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-8.0.0.tgz",
-      "integrity": "sha512-DwiRBlpqwKqGGPmJ5XJwzbyoQLsRBkwicn4coTDDp0f14ZJ7k0/C+zf8nK5TwUilYeP7uNvG9TEnAKohu9dtAw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-8.0.1.tgz",
+      "integrity": "sha512-MdIfyylJUgz50Pk77ZYvOg40a7Fn+tjf/X7h6yuCr0wfzcj2WJFt+Us8eIveN3nAC+8b/bah6YW5+Foqf+i0GA==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^10.0.0",
-    "next-metrics": "^8.0.0",
+    "next-metrics": "^8.0.1",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrades next-metrics to [v8.0.1](https://github.com/Financial-Times/next-metrics/releases/tag/v8.0.1)