### PR TITLE
CPP-1388: Add support for node.js 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
           name: tool-kit/build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.14", "18.16" ]
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -53,7 +53,7 @@ workflows:
           name: tool-kit/test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.14", "18.16" ]
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+(-.+)?/
@@ -87,11 +87,11 @@ workflows:
           name: tool-kit/build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.14", "18.16" ]
       - tool-kit/test:
           requires:
             - tool-kit/build-v<< matrix.node-version >>
           name: tool-kit/test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14" ]
+              node-version: [ "16.14", "18.16" ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@financial-times/n-express",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@dotcom-reliability-kit/errors": "^2.0.0",
         "@dotcom-reliability-kit/serialize-error": "^2.0.0",
@@ -54,8 +53,8 @@
         "typescript": "4.3.5"
       },
       "engines": {
-        "node": "16.x",
-        "npm": "7.x || 8.x"
+        "node": "16.x || 18.x",
+        "npm": "7.x || 8.x || 9.x"
       }
     },
     "node_modules/@actions/exec": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test:types": "tsc",
     "commit": "commit-wizard",
     "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine",
     "build": "dotcom-tool-kit build:local",
     "start": "dotcom-tool-kit run:local"
   },

--- a/package.json
+++ b/package.json
@@ -58,14 +58,13 @@
     "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
   },
   "engines": {
-    "node": "16.x",
-    "npm": "7.x || 8.x"
+    "node": "16.x || 18.x",
+    "npm": "7.x || 8.x || 9.x"
   },
   "config": {},
   "false": {},
   "volta": {
-    "node": "16.14.1",
-    "npm": "7.20.2"
+    "node": "18.16.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
As part of the initial migration of a Platforms owned app (next-ammit-docs) to Node.js 18, I am adding support for Node.js 18 to this library as it is a package that next-ammit-docs consumes.

This will be released as a beta version until we are ready to roll out Node.js 18 support more widely.