### PR TITLE
Update to Node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
       },
       "devDependencies": {
-        "@dotcom-tool-kit/component": "^3.1.5",
+        "@dotcom-tool-kit/component": "^3.1.6",
         "@dotcom-tool-kit/eslint": "^3.1.1",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/lint-staged-npm": "^3.1.1",
@@ -39,7 +39,7 @@
         "@types/node": "12.20.15",
         "chai": "^4.1.2",
         "check-engines": "^1.5.0",
-        "dotcom-tool-kit": "^3.1.6",
+        "dotcom-tool-kit": "^3.1.7",
         "fetch-mock": "^5.1.2",
         "istanbul": "^0.4.5",
         "mocha": "^10.1.0",
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@dotcom-tool-kit/circleci": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci/-/circleci-5.3.2.tgz",
-      "integrity": "sha512-xzglhWCbQ7yZ34GCnyXAsOAunkHQuwl81KMaYZNE4HQEkcBadoKbW2b4MPXIw/O2WdZ4J9qHyh06OwQbpuBg4g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci/-/circleci-5.3.3.tgz",
+      "integrity": "sha512-9CHlfrWha4RFQx397KTTiAffRXcIZNhFiVO7NayifHZP1ntq6IGEDkbcKAp8ayg1yRC38piommprIJBaKPXpXQ==",
       "dev": true,
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -221,12 +221,12 @@
       }
     },
     "node_modules/@dotcom-tool-kit/circleci-npm": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci-npm/-/circleci-npm-5.2.2.tgz",
-      "integrity": "sha512-oFtz0MOS68J5y0PCvut2t4bd4g57F7iLzA9qf/8jO6ld5U0/+PxjqEVcNcWFp+Be3pzT5CUE7W0uxGvwE8fHQg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci-npm/-/circleci-npm-5.2.3.tgz",
+      "integrity": "sha512-11cgDqJLrwKzTSzHmfwFYXpK1AvymNhanLJIhp/mLrnVEpsB8AvcOOvnsJwcHyT9qQYSE6bGzXwHxji9mAX4bQ==",
       "dev": true,
       "dependencies": {
-        "@dotcom-tool-kit/circleci": "^5.3.2",
+        "@dotcom-tool-kit/circleci": "^5.3.3",
         "@dotcom-tool-kit/npm": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.2.0",
         "tslib": "^2.3.1"
@@ -249,12 +249,12 @@
       }
     },
     "node_modules/@dotcom-tool-kit/component": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/component/-/component-3.1.5.tgz",
-      "integrity": "sha512-ju8948mI4eup/VO8btAH5I7okCIFqhluwsjEtvNs4C9Z6G5pxacX+RdYFf8Wtt/+iyqgJiwcXWzw74/Q+nln0A==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/component/-/component-3.1.6.tgz",
+      "integrity": "sha512-o+2FxZZmy7Xx72lN7gPiBg8FGOG9xQyGTJU+GXza5Y43LTPi/RJX6kbtgr/VEiLdn2MC1iEFNNiwocvrhve8Og==",
       "dev": true,
       "dependencies": {
-        "@dotcom-tool-kit/circleci-npm": "^5.2.2",
+        "@dotcom-tool-kit/circleci-npm": "^5.2.3",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/npm": "^3.1.1",
         "@dotcom-tool-kit/secret-squirrel": "^2.1.1"
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/dotcom-tool-kit": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/dotcom-tool-kit/-/dotcom-tool-kit-3.1.6.tgz",
-      "integrity": "sha512-bDdQ5krKYHUgJZkvhdGjd7oP0Z+vcjegznZ34696YXQ9ZuKyXG8Gvkh5kzoX7BNw1BTpMZj9B1/efNcaO0Q4mg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dotcom-tool-kit/-/dotcom-tool-kit-3.1.7.tgz",
+      "integrity": "sha512-jmj7/mSSzLcys3PIxKnpmsxIuy8m31JVos1kHzm+bht/70hD4FuaQ56syFmwWC+09S+/51fSheQJ0aYV1EWnYA==",
       "dev": true,
       "dependencies": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -8722,9 +8722,9 @@
       "integrity": "sha512-lM57ulrbq7ThZJKBLFh/IVZNrrvAAARwiIFZaJV5hYPmQ4/aOlrzS0gfqCV6P1A3yPgAm+6gGyPv5d9ZpQ1RvA=="
     },
     "@dotcom-tool-kit/circleci": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci/-/circleci-5.3.2.tgz",
-      "integrity": "sha512-xzglhWCbQ7yZ34GCnyXAsOAunkHQuwl81KMaYZNE4HQEkcBadoKbW2b4MPXIw/O2WdZ4J9qHyh06OwQbpuBg4g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci/-/circleci-5.3.3.tgz",
+      "integrity": "sha512-9CHlfrWha4RFQx397KTTiAffRXcIZNhFiVO7NayifHZP1ntq6IGEDkbcKAp8ayg1yRC38piommprIJBaKPXpXQ==",
       "dev": true,
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",
@@ -8747,24 +8747,24 @@
       }
     },
     "@dotcom-tool-kit/circleci-npm": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci-npm/-/circleci-npm-5.2.2.tgz",
-      "integrity": "sha512-oFtz0MOS68J5y0PCvut2t4bd4g57F7iLzA9qf/8jO6ld5U0/+PxjqEVcNcWFp+Be3pzT5CUE7W0uxGvwE8fHQg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/circleci-npm/-/circleci-npm-5.2.3.tgz",
+      "integrity": "sha512-11cgDqJLrwKzTSzHmfwFYXpK1AvymNhanLJIhp/mLrnVEpsB8AvcOOvnsJwcHyT9qQYSE6bGzXwHxji9mAX4bQ==",
       "dev": true,
       "requires": {
-        "@dotcom-tool-kit/circleci": "^5.3.2",
+        "@dotcom-tool-kit/circleci": "^5.3.3",
         "@dotcom-tool-kit/npm": "^3.1.1",
         "@dotcom-tool-kit/types": "^3.2.0",
         "tslib": "^2.3.1"
       }
     },
     "@dotcom-tool-kit/component": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/component/-/component-3.1.5.tgz",
-      "integrity": "sha512-ju8948mI4eup/VO8btAH5I7okCIFqhluwsjEtvNs4C9Z6G5pxacX+RdYFf8Wtt/+iyqgJiwcXWzw74/Q+nln0A==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/component/-/component-3.1.6.tgz",
+      "integrity": "sha512-o+2FxZZmy7Xx72lN7gPiBg8FGOG9xQyGTJU+GXza5Y43LTPi/RJX6kbtgr/VEiLdn2MC1iEFNNiwocvrhve8Og==",
       "dev": true,
       "requires": {
-        "@dotcom-tool-kit/circleci-npm": "^5.2.2",
+        "@dotcom-tool-kit/circleci-npm": "^5.2.3",
         "@dotcom-tool-kit/husky-npm": "^4.1.0",
         "@dotcom-tool-kit/npm": "^3.1.1",
         "@dotcom-tool-kit/secret-squirrel": "^2.1.1"
@@ -10305,9 +10305,9 @@
       }
     },
     "dotcom-tool-kit": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/dotcom-tool-kit/-/dotcom-tool-kit-3.1.6.tgz",
-      "integrity": "sha512-bDdQ5krKYHUgJZkvhdGjd7oP0Z+vcjegznZ34696YXQ9ZuKyXG8Gvkh5kzoX7BNw1BTpMZj9B1/efNcaO0Q4mg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dotcom-tool-kit/-/dotcom-tool-kit-3.1.7.tgz",
+      "integrity": "sha512-jmj7/mSSzLcys3PIxKnpmsxIuy8m31JVos1kHzm+bht/70hD4FuaQ56syFmwWC+09S+/51fSheQJ0aYV1EWnYA==",
       "dev": true,
       "requires": {
         "@dotcom-tool-kit/error": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "semver": "^7.3.7"
   },
   "devDependencies": {
-    "@dotcom-tool-kit/component": "^3.1.5",
+    "@dotcom-tool-kit/component": "^3.1.6",
     "@dotcom-tool-kit/eslint": "^3.1.1",
     "@dotcom-tool-kit/husky-npm": "^4.1.0",
     "@dotcom-tool-kit/lint-staged-npm": "^3.1.1",
@@ -40,7 +40,7 @@
     "@types/node": "12.20.15",
     "chai": "^4.1.2",
     "check-engines": "^1.5.0",
-    "dotcom-tool-kit": "^3.1.6",
+    "dotcom-tool-kit": "^3.1.7",
     "fetch-mock": "^5.1.2",
     "istanbul": "^0.4.5",
     "mocha": "^10.1.0",


### PR DESCRIPTION
Automatically ran via Platforms' [migration script](https://github.com/Financial-Times/platform-scripts/blob/464d56876a27742dbdee2713a31266cc268ebfe3/upgrade-node-18/upgrade-node-18.ts)