### PR TITLE
CON-2442 update next metrics to v9.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^10.0.0",
-        "next-metrics": "^8.0.1",
+        "next-metrics": "^9.1.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5737,9 +5737,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-8.0.1.tgz",
-      "integrity": "sha512-MdIfyylJUgz50Pk77ZYvOg40a7Fn+tjf/X7h6yuCr0wfzcj2WJFt+Us8eIveN3nAC+8b/bah6YW5+Foqf+i0GA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.1.0.tgz",
+      "integrity": "sha512-6t7ZbOQZCukEFHQ4kc9WIXF5O7lWq6CY37ucehj1h3OONapnp+7eJaxV/tluuiW1Mmh4LDXtEIAlE/mau2KfVQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^10.2.0",
@@ -12937,9 +12937,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-8.0.1.tgz",
-      "integrity": "sha512-MdIfyylJUgz50Pk77ZYvOg40a7Fn+tjf/X7h6yuCr0wfzcj2WJFt+Us8eIveN3nAC+8b/bah6YW5+Foqf+i0GA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-9.1.0.tgz",
+      "integrity": "sha512-6t7ZbOQZCukEFHQ4kc9WIXF5O7lWq6CY37ucehj1h3OONapnp+7eJaxV/tluuiW1Mmh4LDXtEIAlE/mau2KfVQ==",
       "requires": {
         "@financial-times/n-logger": "^10.2.0",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^10.0.0",
-    "next-metrics": "^8.0.1",
+    "next-metrics": "^9.1.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description**

PR that adds the latest version of next-metrics ([v9.1.0](https://github.com/Financial-Times/next-metrics/releases/tag/v9.1.0)) which adds the additional insights newsletters recommendations API endpoint to the services list.