### PR TITLE
BREAKING: remove Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 - `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality. Backend authentication is required for applications serving traffic that should only come via the Fastly -> Preflight -> Router request routing. An example of why is the Next Article application, if this didn't have backend authentication enabled you would be able to view articles via the heroku application url as it wouldn't be protected by barriers which are handled within Fastly and Preflight.
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
 - `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`
-- `withSentry` - adds [Sentry](https://sentry.io/) error handling, both as an Express error handler and an uncaught exception handler. Defaults to `false`. With this option set to `false` you **must** catch uncaught exceptions yourself; the best-supported way to do this is with the [Reliability Kit crash-handler](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/crash-handler#readme).
 - `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
@@ -79,7 +78,6 @@ As next-metrics must be a singleton to ensure reliable reporting, it is exported
 
 # Other enhancements
 - `fetch` is added as a global using [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch)
-- Errors are sent to sentry using [n-raven](https://github.com/Financial-Times/n-raven)
 - Instrumentation of system and http (incoming and outgoing) performance using [Next Metrics](https://github.com/Financial-Times/next-metrics)
 - Anti-search engine `GET /robots.txt` (possibly might need to change in the future)
 - Exposes various bits of metadata about the app (e.g. name, version, env, isProduction) to templates (via `res.locals`) and the outside world (via `{appname}/__about.json`)

--- a/main.js
+++ b/main.js
@@ -53,7 +53,6 @@ const getAppContainer = (options) => {
 			withBackendAuthentication: true,
 			withFlags: false,
 			withConsent: false,
-			withSentry: false,
 			withServiceMetrics: true,
 			healthChecks: []
 		},
@@ -78,28 +77,10 @@ const getAppContainer = (options) => {
 	/** @type {Promise<any>[]} */
 	const initPromises = [];
 
-	const instrumentListen = new InstrumentListen(express(), meta, initPromises, options);
+	const instrumentListen = new InstrumentListen(express(), meta, initPromises);
 	const app = instrumentListen.app;
 
 	const addInitPromise = initPromises.push.bind(initPromises);
-
-	// Raven must be the first middleware if it's loaded
-	if (options.withSentry) {
-		nLogger.warn({
-			event: 'WITHSENTRY_OPTION_DEPRECATED',
-			message: 'The \'withSentry\' option is deprecated and will be removed from n-express in a future major version'
-		});
-
-		// Note: we require n-raven here because importing n-raven introduces
-		// a lot of side effects. If we don't import it inside this conditional
-		// then it'll always set up unhandled rejection errors. This has a
-		// negligible impact on startup speed – the module has to be loaded
-		// synchronously regardless of whether it's in this conditional or not,
-		// we're just deferring it until later on, when the main `express`
-		// function is called
-		const raven = require('@financial-times/n-raven');
-		app.use(raven.requestHandler());
-	}
 
 	app.get('/robots.txt', robots);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@dotcom-reliability-kit/serialize-request": "^2.0.0",
         "@financial-times/n-flags-client": "^13.0.0",
         "@financial-times/n-logger": "^10.2.0",
-        "@financial-times/n-raven": "^6.3.0",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
@@ -127,15 +126,6 @@
         "kuler": "^2.0.0"
       }
     },
-    "node_modules/@dotcom-reliability-kit/app-info": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
-      "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA==",
-      "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
-      }
-    },
     "node_modules/@dotcom-reliability-kit/errors": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-2.2.0.tgz",
@@ -143,39 +133,6 @@
       "engines": {
         "node": "16.x || 18.x || 20.x",
         "npm": "7.x || 8.x || 9.x"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/log-error": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.5.0.tgz",
-      "integrity": "sha512-cpAe0g3BfwgVC36vr++HGVKOC+ad9wc2xY4H53fFqPTx6v+aeIhp38P1umDWlLShDn+WfSK6Wx1WcBqkL2CC+g==",
-      "dependencies": {
-        "@dotcom-reliability-kit/app-info": "^1.0.3",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-logger": "^10.3.1"
-      },
-      "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/serialize-error": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.1.4.tgz",
-      "integrity": "sha512-5pi/4exUhAP6PTaLzl+3H4Q2lD61C7mZOGWpVWQ5lQmJUq2ilUFo+r3tlfv1GY6sUTmlSUGRkkR+YC3GeJSfVA==",
-      "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/serialize-request": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.1.1.tgz",
-      "integrity": "sha512-JcTAVQ3rmqp+yHxmG2Z1IdjKTAPFIkbThcM8yzagY0qn5k/cfkc3EZGeFdEJ2LiLC3V182xwC2vd4ON8pENi9w==",
-      "engines": {
-        "node": "14.x || 16.x || 18.x",
-        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/serialize-error": {
@@ -832,21 +789,6 @@
         "encoding": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@financial-times/n-raven": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
-      "integrity": "sha512-UnybNv9iriGO1PxAffIUyuU9rRsb788mt12YVBbnawHdCeqPEx2TVqSnMkF6wSM5BLosWh4tB4GmwJgbPErZnw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@dotcom-reliability-kit/log-error": "^1.3.0",
-        "@financial-times/n-logger": "^10.2.0",
-        "raven": "^2.3.0"
-      },
-      "engines": {
-        "node": "14.x || 16.x",
-        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/package-json": {
@@ -1851,14 +1793,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-engines": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/check-engines/-/check-engines-1.5.0.tgz",
@@ -2120,14 +2054,6 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cycle": {
@@ -4149,11 +4075,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -5171,16 +5092,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -6983,42 +6894,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "deprecated": "Please upgrade to @sentry/node. See the migration guide https://bit.ly/3ybOlo7",
-      "dependencies": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "bin": {
-        "raven": "bin/raven"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/raven/node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raven/node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/raw-body": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
@@ -7997,14 +7872,6 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
-    "node_modules/timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8677,38 +8544,10 @@
         "kuler": "^2.0.0"
       }
     },
-    "@dotcom-reliability-kit/app-info": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-1.0.3.tgz",
-      "integrity": "sha512-BVUs2sT48CVJomB8NTjk2aCpEasuWI9Y6RHkDnYP0CZPP1aLao+gIMfyGaCiw/Slhtl6qVs2bClsdIwoesLvjA=="
-    },
     "@dotcom-reliability-kit/errors": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/errors/-/errors-2.2.0.tgz",
       "integrity": "sha512-oEdjSIQyxQPB2ZYlG6iJei3q2Iy1mVElbaHdJAME4hlf3iI9NtY/ONrOtPqnqCZzkIWaBn3/H2SRmZLK23/m5w=="
-    },
-    "@dotcom-reliability-kit/log-error": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-1.5.0.tgz",
-      "integrity": "sha512-cpAe0g3BfwgVC36vr++HGVKOC+ad9wc2xY4H53fFqPTx6v+aeIhp38P1umDWlLShDn+WfSK6Wx1WcBqkL2CC+g==",
-      "requires": {
-        "@dotcom-reliability-kit/app-info": "^1.0.3",
-        "@dotcom-reliability-kit/serialize-error": "^1.1.4",
-        "@dotcom-reliability-kit/serialize-request": "^1.1.0",
-        "@financial-times/n-logger": "^10.3.1"
-      },
-      "dependencies": {
-        "@dotcom-reliability-kit/serialize-error": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-1.1.4.tgz",
-          "integrity": "sha512-5pi/4exUhAP6PTaLzl+3H4Q2lD61C7mZOGWpVWQ5lQmJUq2ilUFo+r3tlfv1GY6sUTmlSUGRkkR+YC3GeJSfVA=="
-        },
-        "@dotcom-reliability-kit/serialize-request": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-1.1.1.tgz",
-          "integrity": "sha512-JcTAVQ3rmqp+yHxmG2Z1IdjKTAPFIkbThcM8yzagY0qn5k/cfkc3EZGeFdEJ2LiLC3V182xwC2vd4ON8pENi9w=="
-        }
-      }
     },
     "@dotcom-reliability-kit/serialize-error": {
       "version": "2.1.0",
@@ -9158,16 +8997,6 @@
             "whatwg-url": "^5.0.0"
           }
         }
-      }
-    },
-    "@financial-times/n-raven": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-raven/-/n-raven-6.3.0.tgz",
-      "integrity": "sha512-UnybNv9iriGO1PxAffIUyuU9rRsb788mt12YVBbnawHdCeqPEx2TVqSnMkF6wSM5BLosWh4tB4GmwJgbPErZnw==",
-      "requires": {
-        "@dotcom-reliability-kit/log-error": "^1.3.0",
-        "@financial-times/n-logger": "^10.2.0",
-        "raven": "^2.3.0"
       }
     },
     "@financial-times/package-json": {
@@ -9981,11 +9810,6 @@
         }
       }
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
-    },
     "check-engines": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/check-engines/-/check-engines-1.5.0.tgz",
@@ -10206,11 +10030,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "cycle": {
       "version": "1.0.3",
@@ -11740,11 +11559,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -12502,16 +12316,6 @@
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
-      }
-    },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "media-typer": {
@@ -13903,30 +13707,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
-    "raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "requires": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw=="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
-    },
     "raw-body": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
@@ -14703,11 +14483,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@dotcom-reliability-kit/serialize-request": "^2.0.0",
     "@financial-times/n-flags-client": "^13.0.0",
     "@financial-times/n-logger": "^10.2.0",
-    "@financial-times/n-raven": "^6.3.0",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
     "express": "^4.17.3",

--- a/src/lib/error-rate-check.js
+++ b/src/lib/error-rate-check.js
@@ -34,6 +34,6 @@ module.exports = (appName, opts) => {
 		businessImpact: 'Users may see application error pages.',
 		technicalSummary: `The proportion of error responses for ${appName} is greater than ${threshold}% of all responses. This is a default n-express check.`,
 		panicGuide:
-			'Consult errors in sentry, application logs in splunk and run the application locally to identify errors'
+			'Consult application logs in splunk and run the application locally to identify errors'
 	});
 };

--- a/test/app/app.test.js
+++ b/test/app/app.test.js
@@ -8,7 +8,6 @@ const metrics = require('next-metrics');
 const sinon = require('sinon');
 const nextExpress = require('../../main');
 const expect = require('chai').expect;
-const raven = require('@financial-times/n-raven');
 const flags = require('@financial-times/n-flags-client');
 
 let app;
@@ -118,7 +117,6 @@ describe('simple app', function () {
 		it('should instrument fetch for recognised services', async function () {
 			const realFetch = global.fetch;
 
-			sinon.stub(raven, 'captureMessage');
 			metricsApp = getApp();
 
 			expect(global.fetch).to.not.equal(realFetch);
@@ -131,9 +129,6 @@ describe('simple app', function () {
 					timeout: 50
 				}).catch(() => {})
 			]);
-
-			expect(raven.captureMessage.called).to.be.false;
-			raven.captureMessage.restore();
 		});
 	});
 

--- a/typings/modules.d.ts
+++ b/typings/modules.d.ts
@@ -1,5 +1,4 @@
 declare module '@financial-times/n-logger';
-declare module '@financial-times/n-raven';
 declare module '@financial-times/n-flags-client';
 declare module 'next-metrics';
 declare module 'n-health';

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -42,7 +42,6 @@ export interface AppOptions extends AppMeta {
 	withConsent: boolean;
 	withBackendAuthentication: boolean;
 	withFlags: boolean;
-	withSentry?: boolean;
 	withServiceMetrics: boolean;
 }
 


### PR DESCRIPTION
**Note to reviewers:** this can't be merged until we're ready to drop Node.js 16 support in the mid-August major version bumps. I'll keep an eye on this PR and rebase `main` onto it until then.

---

This completely removes Sentry from n-express and is the last step towards archiving n-raven and ditching Sentry in our server-side Node.js apps. In order to use this major version of n-express you will need to migrate to [Reliability Kit Crash Handler](https://github.com/Financial-Times/dotcom-reliability-kit/tree/main/packages/crash-handler) to ensure that your unhandled errors are logged to Splunk.

[See the migration guide for more information](https://www.notion.so/Migrating-an-app-off-of-Sentry-c296e30bbf6f4fd3bf0d798f95da3fec).