### PR TITLE
chore: upgrade n-flags-client to 14.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@dotcom-reliability-kit/errors": "^2.0.0",
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "@dotcom-reliability-kit/serialize-request": "^2.0.0",
-        "@financial-times/n-flags-client": "^14.0.0",
+        "@financial-times/n-flags-client": "^14.0.1",
         "debounce": "^1.1.0",
         "denodeify": "^1.2.1",
         "express": "^4.17.3",
@@ -769,9 +769,9 @@
       }
     },
     "node_modules/@financial-times/n-flags-client": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.0.tgz",
-      "integrity": "sha512-h7BIwJAXLVYkhkrbNuDpQ4ENEocIPVFkr+F60xyCzNI5oc1IVKeoB2+Bh6edtd0rZ0S4xkQCsNUrM3in7NfoMw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.1.tgz",
+      "integrity": "sha512-gTwqo4Bzu9GQlGgaBF7U9B6cHt4YVPFPSBuyUNbUPB9TJOvdi7wY0TueBFmOOydcfuF1i2HRJeXP6foTfoBoWw==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "n-eager-fetch": "^7.0.0",
@@ -9390,9 +9390,9 @@
       }
     },
     "@financial-times/n-flags-client": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.0.tgz",
-      "integrity": "sha512-h7BIwJAXLVYkhkrbNuDpQ4ENEocIPVFkr+F60xyCzNI5oc1IVKeoB2+Bh6edtd0rZ0S4xkQCsNUrM3in7NfoMw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-flags-client/-/n-flags-client-14.0.1.tgz",
+      "integrity": "sha512-gTwqo4Bzu9GQlGgaBF7U9B6cHt4YVPFPSBuyUNbUPB9TJOvdi7wY0TueBFmOOydcfuF1i2HRJeXP6foTfoBoWw==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "n-eager-fetch": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@dotcom-reliability-kit/errors": "^2.0.0",
     "@dotcom-reliability-kit/logger": "^2.2.6",
     "@dotcom-reliability-kit/serialize-request": "^2.0.0",
-    "@financial-times/n-flags-client": "^14.0.0",
+    "@financial-times/n-flags-client": "^14.0.1",
     "debounce": "^1.1.0",
     "denodeify": "^1.2.1",
     "express": "^4.17.3",


### PR DESCRIPTION
I propose publishing this as v28.0.2 (patch)

https://github.com/Financial-Times/n-flags-client/pull/190