### PR TITLE
[CON-2875] Update `next-metrics` to `10.0.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^11.0.0",
-        "next-metrics": "^10.0.3",
+        "next-metrics": "^10.0.4",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5810,9 +5810,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.3.tgz",
-      "integrity": "sha512-HtYrmL0h79Bho3oW423oQFEW9Piu+i++cgUNM/HUtU2xlWkNtOwhhp3gWz906PexfoB7qaLmE7zS+S8SY32Z3w==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.4.tgz",
+      "integrity": "sha512-wNS2qQ5UqOC/XTzWl6302MNMfyKeWjg1iGbpVzn6EO1qyeJmAiq1kHrF2doc2iXUug4LZAuJSZwSu3eXd0mi1g==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
@@ -13285,9 +13285,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.3.tgz",
-      "integrity": "sha512-HtYrmL0h79Bho3oW423oQFEW9Piu+i++cgUNM/HUtU2xlWkNtOwhhp3gWz906PexfoB7qaLmE7zS+S8SY32Z3w==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.4.tgz",
+      "integrity": "sha512-wNS2qQ5UqOC/XTzWl6302MNMfyKeWjg1iGbpVzn6EO1qyeJmAiq1kHrF2doc2iXUug4LZAuJSZwSu3eXd0mi1g==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^11.0.0",
-    "next-metrics": "^10.0.3",
+    "next-metrics": "^10.0.4",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## What's changed

This work is required to finish migration from `VoltDB` domains to `SingleStore` ones
 
[Migration guide](https://docs.google.com/document/d/12TC2gyqdz0gb8MOQqXSrW0G7ttfo3jEnakwR9BOeTtU/edit) 
[JiraTask](https://financialtimes.atlassian.net/jira/software/c/projects/CON/boards/1061?assignee=712020%3Adda768db-49f7-48a4-8522-9de57cd1bdfb&selectedIssue=CON-2875)

Migration PR > https://github.com/Financial-Times/next-myft-api/pull/952
`next-metrics` PR > https://github.com/Financial-Times/next-metrics/pull/530
