### PR TITLE
Send WWW-Authenticate header when serving a 401

### DIFF
--- a/src/middleware/backend-authentication.js
+++ b/src/middleware/backend-authentication.js
@@ -69,9 +69,14 @@ module.exports = (app, appName) => {
 				res.set('FT-Backend-Authentication', 'false');
 				/* istanbul ignore else */
 				if (process.env.NODE_ENV === 'production') {
-					// NOTE - setting the status text is very important as it's used by the CDN
-					// to trigger stale-if-error if we mess up the key synchronisation again
-					res.status(401).send('Invalid Backend Key');
+					// Setting the WWW-Authenticate header tells ft.com-cdn
+					// to serve stale content instead of 401s if there's a key error.
+					res.set('WWW-Authenticate', 'FT-Backend-Key');
+					res.status(401).json({
+						status: 'Error',
+						reason: 'Invalid backend key',
+						source: 'n-express'
+					});
 				} else {
 					next();
 				}

--- a/test/app/backend-auth.test.js
+++ b/test/app/backend-auth.test.js
@@ -45,7 +45,7 @@ describe('simple app', function () {
 				.end((err, res) => {
 					// console.log(res);
 					expect(res.status).to.equal(401);
-					expect(res.text).to.equal('Invalid Backend Key');
+					expect(res.get('WWW-Authenticate')).to.equal('FT-Backend-Key');
 					done();
 				});
 		});
@@ -57,7 +57,7 @@ describe('simple app', function () {
 				.expect('ft-backend-authentication', /false/)
 				.end((err, res) => {
 					expect(res.status).to.equal(401);
-					expect(res.text).to.equal('Invalid Backend Key');
+					expect(res.get('WWW-Authenticate')).to.equal('FT-Backend-Key');
 					done();
 				});
 		});
@@ -69,7 +69,7 @@ describe('simple app', function () {
 				.expect('ft-backend-authentication', /false/)
 				.end((err, res) => {
 					expect(res.status).to.equal(401);
-					expect(res.text).to.equal('Invalid Backend Key');
+					expect(res.get('WWW-Authenticate')).to.equal('FT-Backend-Key');
 					done();
 				});
 		});


### PR DESCRIPTION
The previous version of this code claimed to set the HTTP status message to "401 Invalid Backend Key" but this isn't what res.send() does - it sets the HTTP response body.

This means that the logic in ft.com-cdn to read the status message has never worked since it was introduced in 2017.

This commit sets a WWW-Authenticate header which is:

1. in line with [the HTTP spec for 401s][1], although we're not using a standard challenge
2. what we're going to use in ft.com-cdn to switch from a 401 to a 503, because Signal Sciences doesn't support HTTP status messages in any case

I've also added more detail to the response body. This info is public so we need to be careful what we put in here, but I think adding a few details will be useful if/when we need to debug it.

[1]: https://datatracker.ietf.org/doc/html/rfc9110#name-401-unauthorized