### PR TITLE
Update next-metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^11.0.0",
-        "next-metrics": "^10.0.4",
+        "next-metrics": "^10.0.5",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5810,9 +5810,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.4.tgz",
-      "integrity": "sha512-wNS2qQ5UqOC/XTzWl6302MNMfyKeWjg1iGbpVzn6EO1qyeJmAiq1kHrF2doc2iXUug4LZAuJSZwSu3eXd0mi1g==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.5.tgz",
+      "integrity": "sha512-xc/vvgaVE3JIJf8EcnfVKsPCHFFfS1qmdyLwrscd8xHNL4djGaxBStd8JS4p/0Qn1Aw6QaWyrrTRIzBmgWg9gw==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
@@ -13285,9 +13285,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.4.tgz",
-      "integrity": "sha512-wNS2qQ5UqOC/XTzWl6302MNMfyKeWjg1iGbpVzn6EO1qyeJmAiq1kHrF2doc2iXUug4LZAuJSZwSu3eXd0mi1g==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.5.tgz",
+      "integrity": "sha512-xc/vvgaVE3JIJf8EcnfVKsPCHFFfS1qmdyLwrscd8xHNL4djGaxBStd8JS4p/0Qn1Aw6QaWyrrTRIzBmgWg9gw==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^11.0.0",
-    "next-metrics": "^10.0.4",
+    "next-metrics": "^10.0.5",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This is to register the Insights Recommended Articles endpoint that is used in dotcom-pages ([PR](https://github.com/Financial-Times/next-metrics/pull/531)) 