### PR TITLE
Update next-metrics with the new insights service registered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^11.0.0",
-        "next-metrics": "^10.0.5",
+        "next-metrics": "^10.0.6",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5610,9 +5610,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.5.tgz",
-      "integrity": "sha512-xc/vvgaVE3JIJf8EcnfVKsPCHFFfS1qmdyLwrscd8xHNL4djGaxBStd8JS4p/0Qn1Aw6QaWyrrTRIzBmgWg9gw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.6.tgz",
+      "integrity": "sha512-rwQzyxEa2tSmVuK+34zhtx0z1hTtQp3mHxfrsbBz2ROi4WirQw/lc/cE54NSnoLnQ5qpDQyusp4cGgIFkj1hQg==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
@@ -12875,9 +12875,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.5.tgz",
-      "integrity": "sha512-xc/vvgaVE3JIJf8EcnfVKsPCHFFfS1qmdyLwrscd8xHNL4djGaxBStd8JS4p/0Qn1Aw6QaWyrrTRIzBmgWg9gw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.6.tgz",
+      "integrity": "sha512-rwQzyxEa2tSmVuK+34zhtx0z1hTtQp3mHxfrsbBz2ROi4WirQw/lc/cE54NSnoLnQ5qpDQyusp4cGgIFkj1hQg==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^11.0.0",
-    "next-metrics": "^10.0.5",
+    "next-metrics": "^10.0.6",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
The only change is registering a new insight endpoint that is used by dotcom-pages: [PR](https://github.com/Financial-Times/next-metrics/pull/533)