### PR TITLE
update next-metrics with the subs-graphql and com-ft-next-media-renditions services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^11.0.0",
-        "next-metrics": "^10.0.6",
+        "next-metrics": "^10.0.7",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5610,9 +5610,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.6.tgz",
-      "integrity": "sha512-rwQzyxEa2tSmVuK+34zhtx0z1hTtQp3mHxfrsbBz2ROi4WirQw/lc/cE54NSnoLnQ5qpDQyusp4cGgIFkj1hQg==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.7.tgz",
+      "integrity": "sha512-39eHkT60sFxcHUAYx1zr6L//295gDPxOsnHop9dg9CvdNFvjflA1z1A6lJwveNsl70tJVn2D7gmiQeTJyG/4jQ==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
@@ -12875,9 +12875,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.6.tgz",
-      "integrity": "sha512-rwQzyxEa2tSmVuK+34zhtx0z1hTtQp3mHxfrsbBz2ROi4WirQw/lc/cE54NSnoLnQ5qpDQyusp4cGgIFkj1hQg==",
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.7.tgz",
+      "integrity": "sha512-39eHkT60sFxcHUAYx1zr6L//295gDPxOsnHop9dg9CvdNFvjflA1z1A6lJwveNsl70tJVn2D7gmiQeTJyG/4jQ==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^11.0.0",
-    "next-metrics": "^10.0.6",
+    "next-metrics": "^10.0.7",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Update next-metrics with the subs-graphql and com-ft-next-media-renditions services.

Next-metrics release: 
https://github.com/Financial-Times/next-metrics/releases/tag/v10.0.7