### PR TITLE
update next-metrics to 10.0.8 with a fix to subs-graphql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^11.0.0",
-        "next-metrics": "^10.0.7",
+        "next-metrics": "^10.0.8",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5610,9 +5610,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.7.tgz",
-      "integrity": "sha512-39eHkT60sFxcHUAYx1zr6L//295gDPxOsnHop9dg9CvdNFvjflA1z1A6lJwveNsl70tJVn2D7gmiQeTJyG/4jQ==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.8.tgz",
+      "integrity": "sha512-JTF3nSnFUNzZtEPf6WxDUtLkBWl5ia1LDcEqnXA9hKBDqggpHvtq/wRXKFYrYi6qVrZoUpuRvd09nbIOiARRQg==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",
@@ -12875,9 +12875,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.7.tgz",
-      "integrity": "sha512-39eHkT60sFxcHUAYx1zr6L//295gDPxOsnHop9dg9CvdNFvjflA1z1A6lJwveNsl70tJVn2D7gmiQeTJyG/4jQ==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-10.0.8.tgz",
+      "integrity": "sha512-JTF3nSnFUNzZtEPf6WxDUtLkBWl5ia1LDcEqnXA9hKBDqggpHvtq/wRXKFYrYi6qVrZoUpuRvd09nbIOiARRQg==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^2.2.6",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^11.0.0",
-    "next-metrics": "^10.0.7",
+    "next-metrics": "^10.0.8",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Update next-metrics with a subs-graphql service fix.

Next-metrics release:
https://github.com/Financial-Times/next-metrics/releases/tag/v10.0.8