### PR TITLE
Send a Via response header

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,6 +41,7 @@ const teapot = fs.readFileSync(
 	path.join(__dirname, 'src/assets/teapot.ascii'),
 	'utf8'
 );
+const generateViaMiddleware = require('./src/middleware/via');
 
 /**
  * @param {AppOptions} options
@@ -97,6 +98,9 @@ const getAppContainer = (options) => {
 	// Security related headers, see https://securityheaders.io/?q=https%3A%2F%2Fwww.ft.com&hide=on.
 	app.set('x-powered-by', false);
 	app.use(security);
+
+	// Add the application system code to the Via HTTP header
+	app.use(generateViaMiddleware(meta.systemCode));
 
 	// utility middleware
 	app.use(vary);

--- a/src/middleware/via.js
+++ b/src/middleware/via.js
@@ -1,0 +1,16 @@
+/**
+ * @typedef {import("../../typings/n-express").Callback} Callback
+ */
+
+/**
+ * @param {string} systemCode
+ * @returns {Callback}
+ */
+module.exports = function generateViaMiddleware (systemCode) {
+	return (request, response, next) => {
+		const requestVia = request.get('via');
+		const appViaEntry = `${request.httpVersion} ${systemCode}`;
+		response.set('via', requestVia ? `${requestVia}, ${appViaEntry}` : appViaEntry);
+		next();
+	};
+};

--- a/test/middleware/via.test.js
+++ b/test/middleware/via.test.js
@@ -1,0 +1,43 @@
+const generateViaMiddleware = require('../../src/middleware/via');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe('via middleware', function () {
+	let middleware;
+	let request;
+	let response;
+	let next;
+
+	beforeEach(() => {
+		request = {
+			get: sinon.stub().withArgs('via').returns(undefined),
+			httpVersion: 'mock-http-version'
+		};
+		response = {
+			set: sinon.spy()
+		};
+		next = sinon.spy();
+		middleware = generateViaMiddleware('mock-system');
+	});
+
+	describe('when no request Via header is present', () => {
+		it('sends a response Via header set to the application system code', () => {
+			middleware(request, response, next);
+			expect(response.set).calledWithExactly('via', 'mock-http-version mock-system');
+			expect(next).calledWithExactly();
+		});
+	});
+
+	describe('when a request Via header is present', () => {
+		it('sends a response Via header appending the application system code', () => {
+			request.get.withArgs('via').returns('mock-request-via');
+			middleware(request, response, next);
+			expect(response.set).calledWithExactly('via', 'mock-request-via, mock-http-version mock-system');
+			expect(next).calledWithExactly();
+		});
+	});
+
+});


### PR DESCRIPTION
We want to start tracing the paths that requests take through our various proxy layers (Fastly, Heroku router, Heroku dyno, etc). [The HTTP Via header is meant for this](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Via).

Most of the logic is ensuring that we don't lose information from previous proxies ahead of the final n-express app.