### PR TITLE
[CPREL-984] Remove backend auth loophole

### DIFF
--- a/main.js
+++ b/main.js
@@ -144,7 +144,7 @@ const getAppContainer = (options) => {
 	);
 
 	if (options.withBackendAuthentication) {
-		backendAuthentication(app, meta.name);
+		backendAuthentication(app);
 	}
 
 	// feature flags

--- a/src/lib/supported-node-js-version-check.js
+++ b/src/lib/supported-node-js-version-check.js
@@ -1,6 +1,10 @@
 const semver = require('semver');
 
 // Ref. https://nodejs.org/en/about/releases
+
+/**
+ * @type {Object.<string, Date>}
+ */
 const nodeVersionToEndOfLifeDateMap = {
 	'12': new Date('2022-04-30'),
 	'14': new Date('2023-04-30'),

--- a/src/middleware/backend-authentication.js
+++ b/src/middleware/backend-authentication.js
@@ -8,10 +8,9 @@ const metrics = require('next-metrics');
 
 /**
  * @param {Express.Application} app
- * @param {string} appName
  * @returns {void}
  */
-module.exports = (app, appName) => {
+module.exports = (app) => {
 	/** @type {string[]} */
 	const backendKeys = [];
 
@@ -41,12 +40,8 @@ module.exports = (app, appName) => {
 	// @ts-ignore
 	app.use(
 		/** @type {Callback} */ (req, res, next) => {
-			// TODO - change how all this works in order to use __assets/app/{appname}
 			// allow static assets, healthchecks, etc., through
-			if (
-				req.path.indexOf('/' + appName) === 0 ||
-				req.path.indexOf('/__') === 0
-			) {
+			if (req.path.indexOf('/__') === 0) {
 				next();
 			} else if (
 				backendKeys.includes(

--- a/test/app/backend-auth.test.js
+++ b/test/app/backend-auth.test.js
@@ -78,13 +78,6 @@ describe('simple app', function () {
 			request(app).get('/__about').expect(200, done);
 		});
 
-		it('should allow routes named after app through without backend access key', function (done) {
-			request(app)
-				.get('/test-auth/main.css')
-				// it's a 404 as not set up for static assets, but main thing is it isn't a 403
-				.expect(404, done);
-		});
-
 		it('should accept any request with backend access key', function (done) {
 			request(app)
 				.get('/')


### PR DESCRIPTION
For many years this conditional has meant that an app called next-foo will bypass backend authentication for routes that begin /foo.

This is confusing and unnecessary and we should remove it. It'll be a breaking change.

There are very few apps where the first part of their path matches the app name and they all have backend authentication set up correctly:

```
"^/article"                 next-article
"^/globetrotter/(.+)"       next-globetrotter
"^/newsletter-signup"       next-newsletter-signup
"^/profile"                 next-profile
"^/static"                  next-static
```

[JIRA ticket](https://financialtimes.atlassian.net/browse/CPREL-984)

I also added a little type fix because I don't get to write code very much these days and it's fun 🤷 