### PR TITLE
Breaking: remove the `/__about` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ As next-metrics must be a singleton to ensure reliable reporting, it is exported
 - `fetch` is added as a global using [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch)
 - Instrumentation of system and http (incoming and outgoing) performance using [Next Metrics](https://github.com/Financial-Times/next-metrics)
 - Anti-search engine `GET /robots.txt` (possibly might need to change in the future)
-- Exposes various bits of metadata about the app (e.g. name, version, env, isProduction) to templates (via `res.locals`) and the outside world (via `{appname}/__about.json`)
 
 
 

--- a/main.js
+++ b/main.js
@@ -135,14 +135,6 @@ const getAppContainer = (options) => {
 		instrumentListen.addMetrics(serviceMetrics.init());
 	}
 
-	app.get(
-		'/__about',
-		/** @type {Callback} */ (req, res) => {
-			res.set({ 'Cache-Control': 'no-cache' });
-			res.sendFile(meta.directory + '/public/__about.json');
-		}
-	);
-
 	if (options.withBackendAuthentication) {
 		backendAuthentication(app);
 	}

--- a/test/app/app.test.js
+++ b/test/app/app.test.js
@@ -45,10 +45,6 @@ describe('simple app', function () {
 		request(app).get('/robots.txt').expect(200, done);
 	});
 
-	it('should have an about json', function (done) {
-		request(app).get('/__about').expect(200, done);
-	});
-
 	describe('backend access', function () {
 		before(function () {
 			process.env.NODE_ENV = 'production';

--- a/test/app/backend-auth.test.js
+++ b/test/app/backend-auth.test.js
@@ -75,7 +75,7 @@ describe('simple app', function () {
 		});
 
 		it('should allow double-underscorey routes through without backend access key', function (done) {
-			request(app).get('/__about').expect(200, done);
+			request(app).get('/__health').expect(200, done);
 		});
 
 		it('should accept any request with backend access key', function (done) {


### PR DESCRIPTION
This standard never got fully endorsed and our modern tooling (Tool Kit) does not generate the required JSON file anyway. This means that this work is a breaking change for apps that still use n-gage but not for apps using Tool Kit.

Resolves #565.