### PR TITLE
Bumping next-metrics version to 11.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^12.0.0",
-        "next-metrics": "^11.0.0",
+        "next-metrics": "^11.0.1",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5593,9 +5593,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.0.0.tgz",
-      "integrity": "sha512-ulgvWKYl3S6rjNe2k0ZDhfswn0qk9Xr20j2+bLDJarQePKs+ASOBhUdBGhKs45hOGWHOgWL/j0bwAvzPCu2q5A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.0.1.tgz",
+      "integrity": "sha512-EB95u0EjJb1asLb3xNPNRitV2cJiQeFpV8GKmc6H+GtWNVsmurlmZ0/4xihnZlSKwR5WBx54e2aS8iAzWKeq3g==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12776,9 +12776,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.0.0.tgz",
-      "integrity": "sha512-ulgvWKYl3S6rjNe2k0ZDhfswn0qk9Xr20j2+bLDJarQePKs+ASOBhUdBGhKs45hOGWHOgWL/j0bwAvzPCu2q5A==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.0.1.tgz",
+      "integrity": "sha512-EB95u0EjJb1asLb3xNPNRitV2cJiQeFpV8GKmc6H+GtWNVsmurlmZ0/4xihnZlSKwR5WBx54e2aS8iAzWKeq3g==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^12.0.0",
-    "next-metrics": "^11.0.0",
+    "next-metrics": "^11.0.1",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumping next-metrics version to v11.0.1 - https://github.com/Financial-Times/next-metrics/releases/tag/v11.0.1

This version adds redeemable-token api to `next-metrics` service list

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2655