### PR TITLE
update next-metrics to 11.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^12.0.0",
-        "next-metrics": "^11.0.1",
+        "next-metrics": "^11.1.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5593,9 +5593,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.0.1.tgz",
-      "integrity": "sha512-EB95u0EjJb1asLb3xNPNRitV2cJiQeFpV8GKmc6H+GtWNVsmurlmZ0/4xihnZlSKwR5WBx54e2aS8iAzWKeq3g==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.1.0.tgz",
+      "integrity": "sha512-l8zoMXl5BrMSbvDCSr+Kx8OHOIR95jB3OhPjULmUumC14t19dOAVoGEIygsh0wzgcpK8e1y1g7ZNICrASDzByw==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12776,9 +12776,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.0.1.tgz",
-      "integrity": "sha512-EB95u0EjJb1asLb3xNPNRitV2cJiQeFpV8GKmc6H+GtWNVsmurlmZ0/4xihnZlSKwR5WBx54e2aS8iAzWKeq3g==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.1.0.tgz",
+      "integrity": "sha512-l8zoMXl5BrMSbvDCSr+Kx8OHOIR95jB3OhPjULmUumC14t19dOAVoGEIygsh0wzgcpK8e1y1g7ZNICrASDzByw==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^12.0.0",
-    "next-metrics": "^11.0.1",
+    "next-metrics": "^11.1.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Use next-metrics 11.1.0
https://github.com/Financial-Times/next-metrics/releases/tag/v11.1.0

## What's Changed
* Clarify the release process by @rowanmanning in https://github.com/Financial-Times/next-metrics/pull/546
* next-subscribe alerts when it fetches consent by @ludrob in https://github.com/Financial-Times/next-metrics/pull/547
* Remove n-service-worker from services.js by @fenglish in https://github.com/Financial-Times/next-metrics/pull/548


**Full Changelog**: https://github.com/Financial-Times/next-metrics/compare/v11.0.1...v11.1.0