### PR TITLE
update next-metrics to 11.2.0 (added relatedcontent service)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^12.0.0",
-        "next-metrics": "^11.1.0",
+        "next-metrics": "^11.2.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5593,9 +5593,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.1.0.tgz",
-      "integrity": "sha512-l8zoMXl5BrMSbvDCSr+Kx8OHOIR95jB3OhPjULmUumC14t19dOAVoGEIygsh0wzgcpK8e1y1g7ZNICrASDzByw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.2.0.tgz",
+      "integrity": "sha512-Ei4W2LeZDY3KpdiSfIsrWflL3Np7tSz7+N+PPV+LNtwvgnxLcF+AjRFGs33e8llbttmXM+a6+pgSyv8zc1ES4Q==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12776,9 +12776,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.1.0.tgz",
-      "integrity": "sha512-l8zoMXl5BrMSbvDCSr+Kx8OHOIR95jB3OhPjULmUumC14t19dOAVoGEIygsh0wzgcpK8e1y1g7ZNICrASDzByw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.2.0.tgz",
+      "integrity": "sha512-Ei4W2LeZDY3KpdiSfIsrWflL3Np7tSz7+N+PPV+LNtwvgnxLcF+AjRFGs33e8llbttmXM+a6+pgSyv8zc1ES4Q==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^12.0.0",
-    "next-metrics": "^11.1.0",
+    "next-metrics": "^11.2.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Update next-metrics to 11.2.0 (added relatedcontent service - [PR](https://github.com/Financial-Times/next-metrics/pull/549))