### PR TITLE
chore: upgrade next-metrics to 12.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^12.0.0",
-        "next-metrics": "^11.2.0",
+        "next-metrics": "^12.1.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5593,9 +5593,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.2.0.tgz",
-      "integrity": "sha512-Ei4W2LeZDY3KpdiSfIsrWflL3Np7tSz7+N+PPV+LNtwvgnxLcF+AjRFGs33e8llbttmXM+a6+pgSyv8zc1ES4Q==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.1.0.tgz",
+      "integrity": "sha512-5eh21FtkrBTElaHgnvIHQhd6iCN86KfmOXjT/UvJYcylZNkBJqRwEJs7wZO39lyV69p2wlz1uFhfRlsTgJ1eLg==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12776,9 +12776,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-11.2.0.tgz",
-      "integrity": "sha512-Ei4W2LeZDY3KpdiSfIsrWflL3Np7tSz7+N+PPV+LNtwvgnxLcF+AjRFGs33e8llbttmXM+a6+pgSyv8zc1ES4Q==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.1.0.tgz",
+      "integrity": "sha512-5eh21FtkrBTElaHgnvIHQhd6iCN86KfmOXjT/UvJYcylZNkBJqRwEJs7wZO39lyV69p2wlz1uFhfRlsTgJ1eLg==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^12.0.0",
-    "next-metrics": "^11.2.0",
+    "next-metrics": "^12.1.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Use next-metrics 12.1.0
https://github.com/Financial-Times/next-metrics/releases/tag/v12.1.0

## What's Changed
- Update lib/metrics/services.js: graphics-api-proto-eu host has been deleted from Heroku: https://github.com/Financial-Times/next-metrics/pull/501
- CPP-1657: remove next-vault-sync reference: https://github.com/Financial-Times/next-metrics/pull/550
- Remove non-existent services: https://github.com/Financial-Times/next-metrics/pull/473
- Add sub(x) AWS domain: https://github.com/Financial-Times/next-metrics/pull/551


**Full Changelog**: https://github.com/Financial-Times/next-metrics/compare/v11.2.0...v12.1.0