### PR TITLE
chore: upgrade next-metrics to 12.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^12.0.0",
-        "next-metrics": "^12.1.0",
+        "next-metrics": "^12.2.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5593,9 +5593,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.1.0.tgz",
-      "integrity": "sha512-5eh21FtkrBTElaHgnvIHQhd6iCN86KfmOXjT/UvJYcylZNkBJqRwEJs7wZO39lyV69p2wlz1uFhfRlsTgJ1eLg==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.2.0.tgz",
+      "integrity": "sha512-gJTCEVLQh8+b/lqQQayYwOd1mlbt8aC3O/2Tgnfc2gLjq4ypVaIHvsJHl/2Uxwq853TvF8b/9lyEL4b4+jsS3Q==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12776,9 +12776,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.1.0.tgz",
-      "integrity": "sha512-5eh21FtkrBTElaHgnvIHQhd6iCN86KfmOXjT/UvJYcylZNkBJqRwEJs7wZO39lyV69p2wlz1uFhfRlsTgJ1eLg==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.2.0.tgz",
+      "integrity": "sha512-gJTCEVLQh8+b/lqQQayYwOd1mlbt8aC3O/2Tgnfc2gLjq4ypVaIHvsJHl/2Uxwq853TvF8b/9lyEL4b4+jsS3Q==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^12.0.0",
-    "next-metrics": "^12.1.0",
+    "next-metrics": "^12.2.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Use [12.2.0](https://github.com/Financial-Times/next-metrics/releases/tag/v12.2.0) with [commits](https://github.com/financial-times/next-metrics/compare/v12.1.0...v12.2.0) to add spark-pages API metrics.