### PR TITLE
Updating n-metrics version to 12.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.0.0",
-        "next-metrics": "^12.4.0",
+        "next-metrics": "^12.5.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5584,9 +5584,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.4.0.tgz",
-      "integrity": "sha512-vLgbUMtnu1MIMqLjpykaagjtmlCSuFX8cdjUvzXdOHputoGAKkufFusb6iVtv9uioqwC48fG9f7JXAvvAlZ4dg==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.5.0.tgz",
+      "integrity": "sha512-IRuWSeGeytXfjHg0/4389TK3c3tObqfo/nWacPjdhCSyd8yYEcz+GPX8r/FC1+Idiz9W+SBwQFLvM9MFk1e5+A==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12761,9 +12761,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.4.0.tgz",
-      "integrity": "sha512-vLgbUMtnu1MIMqLjpykaagjtmlCSuFX8cdjUvzXdOHputoGAKkufFusb6iVtv9uioqwC48fG9f7JXAvvAlZ4dg==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.5.0.tgz",
+      "integrity": "sha512-IRuWSeGeytXfjHg0/4389TK3c3tObqfo/nWacPjdhCSyd8yYEcz+GPX8r/FC1+Idiz9W+SBwQFLvM9MFk1e5+A==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.0.0",
-    "next-metrics": "^12.4.0",
+    "next-metrics": "^12.5.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
I have added a Sub(x) prod endpoint to next-metrics. Incorporating that new release here - https://github.com/Financial-Times/next-metrics/releases/tag/v12.5.0