### PR TITLE
Update next-metrics to 12.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.0.0",
-        "next-metrics": "^12.5.0",
+        "next-metrics": "^12.8.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5735,9 +5735,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.5.0.tgz",
-      "integrity": "sha512-IRuWSeGeytXfjHg0/4389TK3c3tObqfo/nWacPjdhCSyd8yYEcz+GPX8r/FC1+Idiz9W+SBwQFLvM9MFk1e5+A==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.8.0.tgz",
+      "integrity": "sha512-+RbARfphdEJ4BkPTArkyiPUYhqTK+xAdRXcNGD4OOoOh2hiRVF/m2V1L9ZPSDcV7No0ykeVQCWnDYGi+sjIjnQ==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -13012,9 +13012,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.5.0.tgz",
-      "integrity": "sha512-IRuWSeGeytXfjHg0/4389TK3c3tObqfo/nWacPjdhCSyd8yYEcz+GPX8r/FC1+Idiz9W+SBwQFLvM9MFk1e5+A==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.8.0.tgz",
+      "integrity": "sha512-+RbARfphdEJ4BkPTArkyiPUYhqTK+xAdRXcNGD4OOoOh2hiRVF/m2V1L9ZPSDcV7No0ykeVQCWnDYGi+sjIjnQ==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.0.0",
-    "next-metrics": "^12.5.0",
+    "next-metrics": "^12.8.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Its to have my latest endpoint registered (insights API topic recommendations) .. 

but it also have 3 other sneaky updates that are not from me: 
- Register Sub(x) events API endpoint ([code](https://github.com/Financial-Times/next-metrics/releases/tag/v12.6.0))
- Register pro-central-banking endpoint ([code](https://github.com/Financial-Times/next-metrics/pull/560))
- Bump express from 4.18.2 to 4.19.2 ([code](https://github.com/Financial-Times/next-metrics/pull/552)). The main point of this release is that it 'Prevent open redirect allow list bypass due to encodeurl' 