### PR TITLE
Upgrade next-metrics ^12.9.0 -> ^12.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.0.0",
-        "next-metrics": "^12.9.0",
+        "next-metrics": "^12.10.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5735,9 +5735,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.9.0.tgz",
-      "integrity": "sha512-KbrVs/n3bdpXfBKHVJs/kfzT4d4gZS2Bq/sZWgF08orJ3B+D+l92WU35I7zRe6CTiEaENT3T4+44q3ZukY/0/w==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.10.0.tgz",
+      "integrity": "sha512-mMK4SZp8CkXpXNQ16gMiYXWLYleGRI/10cqBfwV+e0sUE+4IxBtLjwiuBNxb8nerSPWAtTQpjaK/+MbtCutgmw==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -13012,9 +13012,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.9.0.tgz",
-      "integrity": "sha512-KbrVs/n3bdpXfBKHVJs/kfzT4d4gZS2Bq/sZWgF08orJ3B+D+l92WU35I7zRe6CTiEaENT3T4+44q3ZukY/0/w==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.10.0.tgz",
+      "integrity": "sha512-mMK4SZp8CkXpXNQ16gMiYXWLYleGRI/10cqBfwV+e0sUE+4IxBtLjwiuBNxb8nerSPWAtTQpjaK/+MbtCutgmw==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.0.0",
-    "next-metrics": "^12.9.0",
+    "next-metrics": "^12.10.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades next-metrics to consume the changes released in [v12.10.0](https://github.com/Financial-Times/next-metrics/releases/tag/v12.10.0) (which were made by this PR https://github.com/Financial-Times/next-metrics/pull/563).