### PR TITLE
Upgrade next-metrics to version 12.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.0.0",
-        "next-metrics": "^12.10.0",
+        "next-metrics": "^12.11.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5735,9 +5735,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.10.0.tgz",
-      "integrity": "sha512-mMK4SZp8CkXpXNQ16gMiYXWLYleGRI/10cqBfwV+e0sUE+4IxBtLjwiuBNxb8nerSPWAtTQpjaK/+MbtCutgmw==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.11.0.tgz",
+      "integrity": "sha512-F9+EVLuR+ODSIvwDdDWbq3/xebgKnhLWypM4a+ktkqw3HeIaOc+hENpB5jQGK/XXC7XcRtWHN/oF5Tr6iLzf3Q==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -13012,9 +13012,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.10.0.tgz",
-      "integrity": "sha512-mMK4SZp8CkXpXNQ16gMiYXWLYleGRI/10cqBfwV+e0sUE+4IxBtLjwiuBNxb8nerSPWAtTQpjaK/+MbtCutgmw==",
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.11.0.tgz",
+      "integrity": "sha512-F9+EVLuR+ODSIvwDdDWbq3/xebgKnhLWypM4a+ktkqw3HeIaOc+hENpB5jQGK/XXC7XcRtWHN/oF5Tr6iLzf3Q==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.0.0",
-    "next-metrics": "^12.10.0",
+    "next-metrics": "^12.11.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

As part of the work needed to update the healthchecks on next-preflight. See [EU](https://ft-next-preflight-eu.herokuapp.com/__health) and [US](https://ft-next-preflight-us.herokuapp.com/__health) healthchecks
Upgrade next-metrics `^12.10.0 -> ^12.11.0`