### PR TITLE
Remove snyk [automated]

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, which patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "shellpromise": "^1.4.0",
         "sinon": "^4.5.0",
         "sinon-chai": "^3.0.0",
-        "snyk": "^1.167.2",
         "supertest": "^3.0.0",
         "typescript": "4.3.5"
       },
@@ -7705,19 +7704,6 @@
         "npm": ">= 3.0.0"
       }
     },
-    "node_modules/snyk": {
-      "version": "1.981.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.981.0.tgz",
-      "integrity": "sha512-xCXJ74DBsy7vKRdNRJJ3HVFEOEZ2+9eIdRPrgIBQeFcn3zsFgmGo/dva3EN6im75lwxCgVIdKv00bDnM2wyZTA==",
-      "deprecated": "A medium severity vulnerability was found in the Snyk CLI version you are using. We fixed the vulnerability in version 1.996.0. We recommend updating to the latest version. More details here: https://snyk.co/ue1NS",
-      "dev": true,
-      "bin": {
-        "snyk": "bin/snyk"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -14513,12 +14499,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true
-    },
-    "snyk": {
-      "version": "1.981.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.981.0.tgz",
-      "integrity": "sha512-xCXJ74DBsy7vKRdNRJJ3HVFEOEZ2+9eIdRPrgIBQeFcn3zsFgmGo/dva3EN6im75lwxCgVIdKv00bDnM2wyZTA==",
       "dev": true
     },
     "socks": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "dotcom-tool-kit test:local",
     "test:types": "tsc",
     "commit": "commit-wizard",
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
     "build": "dotcom-tool-kit build:local",
     "start": "dotcom-tool-kit run:local"
   },
@@ -47,7 +46,6 @@
     "shellpromise": "^1.4.0",
     "sinon": "^4.5.0",
     "sinon-chai": "^3.0.0",
-    "snyk": "^1.167.2",
     "supertest": "^3.0.0",
     "typescript": "4.3.5"
   },


### PR DESCRIPTION
In mid-December 2024 we will be letting our Snyk contract expire. We'll
be moving to GitHub Advanced Security as an alternative.

This PR is an attempt to get ahead of the deadline. Considering how out
of date some of our Snyk implementations are, and that we rarely take
the time to merge the PRs, we think it's fine to remove it way ahead of
time.

If you want an interrim solution, enable Dependabot Security updates for
this repository by visiting the following page and clicking 'Enable' next
to 'Dependabot security updates':
https://github.com/Financial-Times/n-express/settings/security_analysis

You're also free to ignore this PR and do the work yourself closer to
the deadline. Cyber will be doing some broader comms later in the year.

This PR was automated, please take a little extra care when reviewing. I
won't be attempting to fix build failures or small repo-specific quirks
but feel free to build on top of this PR.