### PR TITLE
chore: ci-2326 bump next-metrics minor version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "express": "^4.17.3",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.0.0",
-        "next-metrics": "^12.11.0",
+        "next-metrics": "^12.12.0",
         "semver": "^7.3.7"
       },
       "bin": {
@@ -5734,9 +5734,9 @@
       "dev": true
     },
     "node_modules/next-metrics": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.11.0.tgz",
-      "integrity": "sha512-F9+EVLuR+ODSIvwDdDWbq3/xebgKnhLWypM4a+ktkqw3HeIaOc+hENpB5jQGK/XXC7XcRtWHN/oF5Tr6iLzf3Q==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.12.0.tgz",
+      "integrity": "sha512-jTBMxv43rYOrqvp/YI+58obu0oKg4UvbbA/VacuJCAbhNM6uPO45kGJzpPAsJEhvh/SyUc7uHyt/RHBEfzQgJA==",
       "dependencies": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",
@@ -12998,9 +12998,9 @@
       "dev": true
     },
     "next-metrics": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.11.0.tgz",
-      "integrity": "sha512-F9+EVLuR+ODSIvwDdDWbq3/xebgKnhLWypM4a+ktkqw3HeIaOc+hENpB5jQGK/XXC7XcRtWHN/oF5Tr6iLzf3Q==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.12.0.tgz",
+      "integrity": "sha512-jTBMxv43rYOrqvp/YI+58obu0oKg4UvbbA/VacuJCAbhNM6uPO45kGJzpPAsJEhvh/SyUc7uHyt/RHBEfzQgJA==",
       "requires": {
         "@dotcom-reliability-kit/logger": "^3.0.3",
         "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "express": "^4.17.3",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.0.0",
-    "next-metrics": "^12.11.0",
+    "next-metrics": "^12.12.0",
     "semver": "^7.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
new version of next-metrics that adds support for the current triallist endpoint of subs graphql query