### PR TITLE
Reduce the bundle size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.circleci
+.editorconfig
+.eslintrc.js
+.github
+.nvmrc
+.prettierrc
+.toolkit*
+CODEOWNERS
+renovate.json
+secret-squirrel.js
+test
+tsconfig.json


### PR DESCRIPTION
We're not ignoring anything when publishing this module. It's not a major thing but we can reduce a bit of overhead.

By adding an `.npmignore` file we go from
23.2 KB packed, 80.4 KB unpacked to
15.9 KB packed, 48.6 KB unpacked.

That's 7.3 KB less each time someone downloads this module. Based on npm downloads, that's about 21.9 MB of downloading saved per month.