### PR TITLE
only include isomorphic-fetch if the application has explicitly disabled native fetch

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,13 @@
  * @typedef {import("./typings/metrics").TickingMetric} TickingMetric
  */
 
-require('isomorphic-fetch');
+// only include isomorphic-fetch if the application has explicitly disabled native fetch
+if (
+	process.allowedNodeEnvironmentFlags.has('--no-experimental-fetch') &&
+	process.execArgv.includes('--no-experimental-fetch')
+) {
+	require('isomorphic-fetch');
+}
 
 const fs = require('fs');
 const path = require('path');
@@ -68,7 +74,8 @@ const getAppContainer = (options) => {
 	if (options.withAb) {
 		logger.warn({
 			event: 'WITHAB_OPTION_DEPRECATED',
-			message: 'The \'withAb\' option is deprecated and no longer supported by n-express or n-flags-client'
+			message:
+				"The 'withAb' option is deprecated and no longer supported by n-express or n-flags-client"
 		});
 	}
 


### PR DESCRIPTION
this will allow us to gradually enable native fetch in apps without a breaking change. by default, apps on Node 18 using Tool Kit set this flag. once everything has migrated to native fetch we can remove the dependency on `isomorphic-fetch`.