### PR TITLE
Sort out the types

### DIFF
--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -5,15 +5,20 @@ plugins:
   - '@dotcom-tool-kit/husky-npm'
   - '@dotcom-tool-kit/lint-staged-npm'
   - '@dotcom-tool-kit/node'
+  - '@dotcom-tool-kit/typescript'
 commands:
   test:local:
     - Eslint
+    - TypeScript
     - Mocha
   test:ci:
     - Eslint
+    - TypeScript
     - Mocha
   git:precommit:
     - LintStaged
+  run:local:
+    - Node
 options:
   plugins:
     '@dotcom-tool-kit/circleci':

--- a/main.js
+++ b/main.js
@@ -1,8 +1,6 @@
 /**
- * @typedef {import("express").Application} Application
- * @typedef {import("./typings/n-express").Callback} Callback
- * @typedef {import("./typings/n-express").AppOptions} AppOptions
- * @typedef {import("./typings/n-express").AppContainer} AppContainer
+ * @import {Application} from 'express'
+ * @import {AppContainer, AppOptions, Callback} from './typings/n-express'
  */
 
 require('isomorphic-fetch');

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@dotcom-tool-kit/lint-staged-npm": "^4.0.2",
         "@dotcom-tool-kit/mocha": "^4.0.2",
         "@dotcom-tool-kit/node": "^4.0.2",
+        "@dotcom-tool-kit/typescript": "^3.0.2",
         "@financial-times/eslint-config-next": "^7.1.0",
         "@tsconfig/node18": "^18.2.4",
         "@types/express": "4.17.21",
@@ -737,6 +738,25 @@
       "engines": {
         "node": "18.x || 20.x",
         "npm": "7.x || 8.x || 9.x || 10.x"
+      }
+    },
+    "node_modules/@dotcom-tool-kit/typescript": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/typescript/-/typescript-3.0.2.tgz",
+      "integrity": "sha512-wPwzPEhXZqlnk4MDU2O4MHr9YHP8cPTjdpIwji4lbswHW2MSZRd39siqZmU8rZ56lta2TSheY3qS6YcjDNDRTg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@dotcom-tool-kit/base": "^1.0.0",
+        "@dotcom-tool-kit/logger": "^4.0.0"
+      },
+      "engines": {
+        "node": "18.x || 20.x",
+        "npm": "7.x || 8.x || 9.x || 10.x"
+      },
+      "peerDependencies": {
+        "dotcom-tool-kit": "4.x",
+        "typescript": "3.x || 4.x || 5.x"
       }
     },
     "node_modules/@dotcom-tool-kit/validated": {
@@ -8497,6 +8517,16 @@
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
+      }
+    },
+    "@dotcom-tool-kit/typescript": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@dotcom-tool-kit/typescript/-/typescript-3.0.2.tgz",
+      "integrity": "sha512-wPwzPEhXZqlnk4MDU2O4MHr9YHP8cPTjdpIwji4lbswHW2MSZRd39siqZmU8rZ56lta2TSheY3qS6YcjDNDRTg==",
+      "dev": true,
+      "requires": {
+        "@dotcom-tool-kit/base": "^1.0.0",
+        "@dotcom-tool-kit/logger": "^4.0.0"
       }
     },
     "@dotcom-tool-kit/validated": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@dotcom-tool-kit/mocha": "^4.0.2",
         "@dotcom-tool-kit/node": "^4.0.2",
         "@financial-times/eslint-config-next": "^7.1.0",
-        "@tsconfig/node12": "12.1.3",
+        "@tsconfig/node18": "^18.2.4",
         "@types/express": "4.17.21",
         "@types/isomorphic-fetch": "0.0.39",
         "@types/node": "12.20.15",
@@ -37,7 +37,7 @@
         "sinon": "^4.5.0",
         "sinon-chai": "^3.0.0",
         "supertest": "^3.0.0",
-        "typescript": "4.3.5"
+        "typescript": "^5.6.3"
       },
       "engines": {
         "node": "18.x || 20.x",
@@ -1196,11 +1196,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node12": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-12.1.3.tgz",
-      "integrity": "sha512-3dneYOMd/Xi7/3FRxncBRB2VpES2ykiEfDIRES3ipf9+XEiC/7982kbaJXV5aPwgER7VQZ0KtE7ZR4HhxTYneg==",
-      "dev": true
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -7406,9 +7407,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7416,7 +7417,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -8850,10 +8851,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tsconfig/node12": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-12.1.3.tgz",
-      "integrity": "sha512-3dneYOMd/Xi7/3FRxncBRB2VpES2ykiEfDIRES3ipf9+XEiC/7982kbaJXV5aPwgER7VQZ0KtE7ZR4HhxTYneg==",
+    "@tsconfig/node18": {
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
+      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
       "dev": true
     },
     "@types/body-parser": {
@@ -13600,9 +13601,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@dotcom-tool-kit/lint-staged-npm": "^4.0.2",
     "@dotcom-tool-kit/mocha": "^4.0.2",
     "@dotcom-tool-kit/node": "^4.0.2",
+    "@dotcom-tool-kit/typescript": "^3.0.2",
     "@financial-times/eslint-config-next": "^7.1.0",
     "@tsconfig/node18": "^18.2.4",
     "@types/express": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@dotcom-tool-kit/mocha": "^4.0.2",
     "@dotcom-tool-kit/node": "^4.0.2",
     "@financial-times/eslint-config-next": "^7.1.0",
-    "@tsconfig/node12": "12.1.3",
+    "@tsconfig/node18": "^18.2.4",
     "@types/express": "4.17.21",
     "@types/isomorphic-fetch": "0.0.39",
     "@types/node": "12.20.15",
@@ -37,7 +37,7 @@
     "sinon": "^4.5.0",
     "sinon-chai": "^3.0.0",
     "supertest": "^3.0.0",
-    "typescript": "4.3.5"
+    "typescript": "^5.6.3"
   },
   "bin": {
     "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"

--- a/src/lib/guess-app-details.js
+++ b/src/lib/guess-app-details.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").AppMeta} AppMeta
+ * @import {AppMeta} from '../../typings/n-express'
  */
 
 const normalizeName = require('./normalize-name');

--- a/src/lib/health-checks.js
+++ b/src/lib/health-checks.js
@@ -1,6 +1,6 @@
 /**
- * @typedef {import("express").Application} ExpressApp
- * @typedef {import("../../typings/n-express").AppOptions} AppOptions
+ * @import {Application as ExpressApp} from 'express'
+ * @import {AppOptions} from '../../typings/n-express'
  */
 
 const logger = require('@dotcom-reliability-kit/logger');

--- a/src/middleware/anon.js
+++ b/src/middleware/anon.js
@@ -1,7 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
- * @typedef {import("../../typings/n-express").Request} Request
- * @typedef {import("../../typings/n-express").Response} Response
+ * @import {Callback, Request, Response} from '../../typings/n-express'
  */
 
 /**

--- a/src/middleware/anon.js
+++ b/src/middleware/anon.js
@@ -5,7 +5,7 @@
  */
 
 /**
- * @type {Callback}
+ * @param {Request} req
  */
 function AnonymousModel (req) {
 	if (req.get('FT-Anonymous-User') === 'true') {

--- a/src/middleware/backend-authentication.js
+++ b/src/middleware/backend-authentication.js
@@ -1,6 +1,5 @@
 /**
- * @typedef {import("express")} Express
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import Express from 'express'
  */
 
 const logger = require('@dotcom-reliability-kit/logger');
@@ -39,7 +38,7 @@ module.exports = (app) => {
 
 	// @ts-ignore
 	app.use(
-		/** @type {Callback} */ (req, res, next) => {
+		/** @type {Express.Handler} */ (req, res, next) => {
 			// allow static assets, healthchecks, etc., through
 			if (req.path.indexOf('/__') === 0) {
 				next();

--- a/src/middleware/cache.js
+++ b/src/middleware/cache.js
@@ -1,6 +1,9 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
- * @typedef {[key: keyof import("../../typings/n-express").CacheHeaders, val: string]} CacheHeader
+ * @import {Callback, CacheHeaders} from '../../typings/n-express'
+ */
+
+/**
+ * @typedef {[key: keyof CacheHeaders, val: string]} CacheHeader
  */
 
 const cacheHeaders = {

--- a/src/middleware/consent.js
+++ b/src/middleware/consent.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import {Callback} from '../../typings/n-express'
  */
 
 /**

--- a/src/middleware/log-vary.js
+++ b/src/middleware/log-vary.js
@@ -17,7 +17,7 @@ module.exports = (req, res, next) => {
 				event: 'RESPONSE_VARY',
 				path: req.path
 			};
-			const vary = res.get('vary').replace(/ /g, '').split(',');
+			const vary = res.get('vary')?.replace(/ /g, '').split(',');
 
 			if (!vary) {
 				return;

--- a/src/middleware/log-vary.js
+++ b/src/middleware/log-vary.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import {Callback} from '../../typings/n-express'
  */
 
 const logger = require('@dotcom-reliability-kit/logger');

--- a/src/middleware/robots.js
+++ b/src/middleware/robots.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import {Callback} from '../../typings/n-express'
  */
 
 const fs = require('fs');

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import {Callback} from '../../typings/n-express'
  */
 
 /**

--- a/src/middleware/vary.js
+++ b/src/middleware/vary.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import {Callback} from '../../typings/n-express'
  */
 
 /**

--- a/src/middleware/via.js
+++ b/src/middleware/via.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import("../../typings/n-express").Callback} Callback
+ * @import {Callback} from '../../typings/n-express'
  */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "noEmit": true,
     "noImplicitAny": true,
     "resolveJsonModule": true,
+    "strict": true,
     "esModuleInterop": true
   },
   "include": ["./main.js", "./typings", "./src"]

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -32,6 +32,8 @@ export interface AppMeta {
 	systemCode: string;
 }
 export interface AppOptions extends AppMeta {
+	/** @deprecated */
+	withAb?: boolean;
 	healthChecksAppName?: string;
 	healthChecks: Metrics.Healthcheck[];
 	errorRateHealthcheck?: ErrorRateHealthcheckOptions;


### PR DESCRIPTION
This does a bunch of stuff to bring the types up to date:

  * Updates the TypeScript-related packages to match the versions of Node.js we support (18+ currently)
  * Fixes all the TypeScript errors, all of these turned out to be fine and non-breaking
  * Adds the Tool Kit TypeScript package to the test command so that things can't break again
  * Adds strict type checking to avoid a few gotchas being added later
  * Migrates JSDoc to `@import` statements which are neater