### PR TITLE
chore!: stop sending metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 - `withBackendAuthentication` - Boolean, defaults to `true` - if there is a `FT_NEXT_BACKEND_KEY[_OLD]` env variable, the app will expect requests to have an equivalent `FT-Next-Backend-Key[-Old]` header; this turns off that functionality. Backend authentication is required for applications serving traffic that should only come via the Fastly -> Preflight -> Router request routing. An example of why is the Next Article application, if this didn't have backend authentication enabled you would be able to view articles via the heroku application url as it wouldn't be protected by barriers which are handled within Fastly and Preflight.
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
 - `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`
-- `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 - `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.
@@ -45,7 +44,6 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 ## Static properties and methods
 - `Router` - `express.Router`
 - `static` - `express.static` middleware
-- `metrics` - `next-metrics` instance
 - `flags` - `n-flags-client` instance
 - `getAppContainer()` - returns an object:
 	- `app`: the express app instance
@@ -72,13 +70,8 @@ Various vary headers are set by default (ft-flags, ft-anonymous-user, ft-edition
 - `res.unvaryAll()` - remove all vary headers. *Do not use lightly!!!*
 - `res.vary('My-Header')` - add to the list of vary headers
 
-## next-metrics
-As next-metrics must be a singleton to ensure reliable reporting, it is exported at `require('@financial-times/n-express').metrics`. To send metrics under a variant app name (e.g. a canary app) set the environment variable `FT_APP_VARIANT`.
-
 # Other enhancements
 - `fetch` is added as a global using [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch)
-- Instrumentation of system and http (incoming and outgoing) performance using [Next Metrics](https://github.com/Financial-Times/next-metrics)
-- Anti-search engine `GET /robots.txt` (possibly might need to change in the future)
 
 
 

--- a/main.js
+++ b/main.js
@@ -50,7 +50,6 @@ const getAppContainer = (options) => {
 			withBackendAuthentication: true,
 			withFlags: false,
 			withConsent: false,
-			withServiceMetrics: true,
 			healthChecks: []
 		},
 		options || {}
@@ -113,22 +112,6 @@ const getAppContainer = (options) => {
 			next();
 		}
 	);
-
-	// metrics should be one of the first things as needs to be applied before any other middleware executes
-	metrics.init({
-		flushEvery: 40000
-	});
-	app.use(
-		/** @type {Callback} */ (req, res, next) => {
-			metrics.instrument(req, { as: 'express.http.req' });
-			metrics.instrument(res, { as: 'express.http.res' });
-			next();
-		}
-	);
-
-	if (options.withServiceMetrics) {
-		metrics.fetch.instrument();
-	}
 
 	if (options.withBackendAuthentication) {
 		backendAuthentication(app);

--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-const metrics = require('next-metrics');
 const logger = require('@dotcom-reliability-kit/logger');
 const http = require('http');
 const https = require('https');
@@ -93,7 +92,6 @@ module.exports = class InstrumentListen {
 			try {
 				await Promise.all(initPromises);
 
-				metrics.count('express.start');
 				const server = await this.createServer();
 				this.server = server;
 				return server.listen(port, wrappedCallback);

--- a/src/middleware/backend-authentication.js
+++ b/src/middleware/backend-authentication.js
@@ -3,7 +3,6 @@
  */
 
 const logger = require('@dotcom-reliability-kit/logger');
-const metrics = require('next-metrics');
 
 /**
  * @param {Express.Application} app
@@ -47,7 +46,6 @@ module.exports = (app) => {
 					/** @type {string} */ (req.get('FT-Next-Backend-Key'))
 				)
 			) {
-				metrics.count('express.backend_authentication.backend_key');
 				res.set('FT-Backend-Authentication', 'true');
 				next();
 			} else if (
@@ -55,11 +53,9 @@ module.exports = (app) => {
 					/** @type {string} */ (req.get('FT-Next-Backend-Key-Old'))
 				)
 			) {
-				metrics.count('express.backend_authentication.old_backend_key');
 				res.set('FT-Backend-Authentication', 'true');
 				next();
 			} else {
-				metrics.count('express.backend_authentication.fail');
 				res.set('FT-Backend-Authentication', 'false');
 				if (process.env.NODE_ENV === 'production') {
 					// Setting the WWW-Authenticate header tells ft.com-cdn

--- a/test/app/app.test.js
+++ b/test/app/app.test.js
@@ -1,10 +1,8 @@
-/*global it, global, describe, beforeEach, before, after*/
-const path = require('path');
+/*global it, describe, before, after*/
 const request = require('supertest');
 
 // stub the setup api calls
 const fetchMock = require('fetch-mock');
-const metrics = require('next-metrics');
 const sinon = require('sinon');
 const nextExpress = require('../../main');
 const expect = require('chai').expect;
@@ -60,71 +58,6 @@ describe('simple app', function () {
 				.expect(200, () => {
 					done();
 				});
-		});
-	});
-
-	describe('metrics', function () {
-		let metricsApp;
-
-		beforeEach(function () {
-			delete flags.url;
-			global.fetch.restore();
-			// fake metrics has not been initialised
-			delete metrics.graphite;
-		});
-
-		afterEach(function () {
-			metricsApp.close();
-		});
-
-		function getApp (conf) {
-			conf = conf || {};
-			conf.directory = path.resolve(__dirname, '../fixtures/app/');
-			conf.systemCode = 'test-app';
-			return nextExpress(conf);
-		}
-
-		it('should initialise metrics', function () {
-			sinon.stub(metrics, 'init');
-			metricsApp = getApp();
-			expect(metrics.init.calledWith({ flushEvery: 40000 })).to.be.true;
-			metrics.init.restore();
-		});
-
-		it('should initialise metrics for variant apps', function () {
-			sinon.stub(metrics, 'init');
-			process.env.FT_APP_VARIANT = 'testing';
-			metricsApp = getApp();
-			expect(metrics.init.calledWith({ flushEvery: 40000 })).to.be.true;
-			metrics.init.restore();
-			delete process.env.FT_APP_VARIANT;
-		});
-
-		it('should count application starts', async function () {
-			sinon.stub(metrics, 'count');
-
-			metricsApp = getApp();
-			await metricsApp.listen();
-
-			expect(metrics.count.calledWith('express.start')).to.be.true;
-			metrics.count.restore();
-		});
-
-		it('should instrument fetch for recognised services', async function () {
-			const realFetch = global.fetch;
-
-			metricsApp = getApp();
-
-			expect(global.fetch).to.not.equal(realFetch);
-
-			await Promise.all([
-				fetch('http://ft-next-api-user-prefs-v002.herokuapp.com/', {
-					timeout: 50
-				}).catch(() => {}),
-				fetch('http://bertha.ig.ft.com/ghjgjh', {
-					timeout: 50
-				}).catch(() => {})
-			]);
 		});
 	});
 

--- a/test/app/clear-interval.test.js
+++ b/test/app/clear-interval.test.js
@@ -25,7 +25,6 @@ describe('clears intervals', () => {
 			systemCode: 'test-app',
 			withFlags: false,
 			demo: false, // adds health check that sets interval
-			withServiceMetrics: true // adds service check that sets interval
 		});
 
 


### PR DESCRIPTION
This doesn't fully remove next-metrics to avoid a large migration, however it does stop n-express from sending any metrics to Graphite by default. This is a breaking change because the lack of metrics could trigger alerts for some apps as data will stop being available for things like `fetch`.

The second part of this work will arrive when we roll out next-metrics v13, after [this PR](https://github.com/Financial-Times/next-metrics/pull/603) is merged.

**Note: this is a breaking change, note that it's being PRed into the `next` branch**