### PR TITLE
feat!: bump next-metrics to v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "express": "^4.21.1",
         "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.1.1",
-        "next-metrics": "^12.15.1"
+        "next-metrics": "^13.0.0"
       },
       "bin": {
         "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
@@ -848,15 +848,15 @@
       }
     },
     "node_modules/@dotcom-reliability-kit/logger": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-3.1.6.tgz",
-      "integrity": "sha512-PgUTWmcX48Aq+v2VzXeZb/BkBiCorL90Y7e8ghamjV7OOfsRRxj8H95cVtt33GK7n8HpyrZHNtamh4YrzxQHaQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-3.2.0.tgz",
+      "integrity": "sha512-/U9H4JlWYEzTZ1yk7yC+7NCo0D/eqRDP8TsIxo34oMoVyrBgEU3tcPIkshtAYfW3oxThlQO5++Q54wnuo/wT5g==",
       "license": "MIT",
       "dependencies": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
-        "pino": "^9.4.0"
+        "pino": "^9.5.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -866,69 +866,16 @@
         "pino-pretty": ">=7.0.0 <11.0.0"
       }
     },
-    "node_modules/@dotcom-reliability-kit/logger/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/logger/node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/@dotcom-reliability-kit/logger/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@dotcom-reliability-kit/logger/node_modules/pino": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-      "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
+      "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^1.2.0",
+        "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
         "process-warning": "^4.0.0",
         "quick-format-unescaped": "^4.0.3",
@@ -942,12 +889,11 @@
       }
     },
     "node_modules/@dotcom-reliability-kit/logger/node_modules/pino-abstract-transport": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
       }
     },
@@ -963,26 +909,10 @@
       "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw==",
       "license": "MIT"
     },
-    "node_modules/@dotcom-reliability-kit/logger/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@dotcom-reliability-kit/logger/node_modules/sonic-boom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-      "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -5412,7 +5342,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -5596,25 +5527,6 @@
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/metrics": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/metrics/-/metrics-0.1.21.tgz",
-      "integrity": "sha512-Lg/0Kj7fani6FDmlC99glxpPjK3GHzE50Hp6IVIaMhGc9ZxR2MF0Eo4haOl1C0cGWpRkViv45P0hdvRJghkJtQ==",
-      "dependencies": {
-        "events": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.x"
-      }
-    },
-    "node_modules/metrics/node_modules/events": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/micromatch": {
@@ -6109,13 +6021,11 @@
       }
     },
     "node_modules/next-metrics": {
-      "version": "12.15.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.15.1.tgz",
-      "integrity": "sha512-+THD/EOMwClXyIgoqHNnt0eWfjUQ1YP8T/bXYyptHmi9mB6ncyW1AFy7ilHEh++EdqT0C3RK7sf+ZXYaSfluAw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-13.0.0.tgz",
+      "integrity": "sha512-mAPJzyX8DcAqMFMBDFED4f5nLiP1ljdJT+Zc2eYXc2zraSLtzWLDjN29s5l+fzhjv3gLbsNc2a6avplPYRTNKw==",
       "dependencies": {
-        "@dotcom-reliability-kit/logger": "^3.1.4",
-        "lodash": "^4.17.21",
-        "metrics": "^0.1.8"
+        "@dotcom-reliability-kit/logger": "^3.2.0"
       },
       "engines": {
         "node": "18.x || 20.x || 22.x",
@@ -9313,44 +9223,25 @@
       "integrity": "sha512-Y0GF/9U1KKZG0l7MtdoysFOwDCsTmS5gJWnf9ZrpHgN+SLNxY5yx1vjsbjEfIYEwIalI8lSj87F6Y3fYTsUyIw=="
     },
     "@dotcom-reliability-kit/logger": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-3.1.6.tgz",
-      "integrity": "sha512-PgUTWmcX48Aq+v2VzXeZb/BkBiCorL90Y7e8ghamjV7OOfsRRxj8H95cVtt33GK7n8HpyrZHNtamh4YrzxQHaQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-3.2.0.tgz",
+      "integrity": "sha512-/U9H4JlWYEzTZ1yk7yC+7NCo0D/eqRDP8TsIxo34oMoVyrBgEU3tcPIkshtAYfW3oxThlQO5++Q54wnuo/wT5g==",
       "requires": {
         "@dotcom-reliability-kit/app-info": "^3.3.0",
         "@dotcom-reliability-kit/serialize-error": "^3.2.0",
         "lodash.clonedeep": "^4.5.0",
-        "pino": "^9.4.0"
+        "pino": "^9.5.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "events": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-        },
-        "ieee754": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-        },
         "pino": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/pino/-/pino-9.4.0.tgz",
-          "integrity": "sha512-nbkQb5+9YPhQRz/BeQmrWpEknAaqjpAqRK8NwJpmrX/JHu7JuZC5G1CeAwJDJfGes4h+YihC6in3Q2nGb+Y09w==",
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-9.5.0.tgz",
+          "integrity": "sha512-xSEmD4pLnV54t0NOUN16yCl7RIB1c5UUOse5HSyEXtBp+FgFQyPeDutc+Q2ZO7/22vImV7VfEjH/1zV2QuqvYw==",
           "requires": {
             "atomic-sleep": "^1.0.0",
             "fast-redact": "^3.1.1",
             "on-exit-leak-free": "^2.1.0",
-            "pino-abstract-transport": "^1.2.0",
+            "pino-abstract-transport": "^2.0.0",
             "pino-std-serializers": "^7.0.0",
             "process-warning": "^4.0.0",
             "quick-format-unescaped": "^4.0.3",
@@ -9361,11 +9252,10 @@
           }
         },
         "pino-abstract-transport": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
-          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+          "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
           "requires": {
-            "readable-stream": "^4.0.0",
             "split2": "^4.0.0"
           }
         },
@@ -9379,22 +9269,10 @@
           "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.0.tgz",
           "integrity": "sha512-/MyYDxttz7DfGMMHiysAsFE4qF+pQYAA8ziO/3NcRVrQ5fSk+Mns4QZA/oRPFzvcqNoVJXQNWNAsdwBXLUkQKw=="
         },
-        "readable-stream": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        },
         "sonic-boom": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.1.0.tgz",
-          "integrity": "sha512-NGipjjRicyJJ03rPiZCJYjwlsuP2d1/5QUviozRXC7S3WdVWNK5e3Ojieb9CCyfhq2UC+3+SRd9nG3I2lPRvUw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+          "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
           "requires": {
             "atomic-sleep": "^1.0.0"
           }
@@ -12816,7 +12694,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -12966,21 +12845,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
-    },
-    "metrics": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/metrics/-/metrics-0.1.21.tgz",
-      "integrity": "sha512-Lg/0Kj7fani6FDmlC99glxpPjK3GHzE50Hp6IVIaMhGc9ZxR2MF0Eo4haOl1C0cGWpRkViv45P0hdvRJghkJtQ==",
-      "requires": {
-        "events": "^2.0.0"
-      },
-      "dependencies": {
-        "events": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
-          "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
-        }
-      }
     },
     "micromatch": {
       "version": "4.0.8",
@@ -13358,13 +13222,11 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "next-metrics": {
-      "version": "12.15.1",
-      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-12.15.1.tgz",
-      "integrity": "sha512-+THD/EOMwClXyIgoqHNnt0eWfjUQ1YP8T/bXYyptHmi9mB6ncyW1AFy7ilHEh++EdqT0C3RK7sf+ZXYaSfluAw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/next-metrics/-/next-metrics-13.0.0.tgz",
+      "integrity": "sha512-mAPJzyX8DcAqMFMBDFED4f5nLiP1ljdJT+Zc2eYXc2zraSLtzWLDjN29s5l+fzhjv3gLbsNc2a6avplPYRTNKw==",
       "requires": {
-        "@dotcom-reliability-kit/logger": "^3.1.4",
-        "lodash": "^4.17.21",
-        "metrics": "^0.1.8"
+        "@dotcom-reliability-kit/logger": "^3.2.0"
       }
     },
     "nise": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express": "^4.21.1",
     "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.1.1",
-    "next-metrics": "^12.15.1"
+    "next-metrics": "^13.0.0"
   },
   "devDependencies": {
     "@dotcom-tool-kit/component": "^5.0.3",


### PR DESCRIPTION
This means that apps using n-express will no longer be sending _any_ metrics to Graphite unless they manually install and set up next-metrics.