### PR TITLE
Drop support for Node.js 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,6 @@ executors:
   node20_18:
     docker:
       - image: cimg/node:20.18
-  node18_20:
-    docker:
-      - image: cimg/node:18.20
 jobs:
   checkout:
     docker:
@@ -41,7 +38,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - checkout
           filters:
@@ -54,7 +50,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/setup-<< matrix.executor >>
           filters:
@@ -67,7 +62,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/build-<< matrix.executor >>
           filters:
@@ -101,7 +95,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - checkout
       - tool-kit/build:
@@ -111,7 +104,6 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/setup-<< matrix.executor >>
       - tool-kit/test:
@@ -121,6 +113,5 @@ workflows:
               executor:
                 - node
                 - node20_18
-                - node18_20
           requires:
             - tool-kit/build-<< matrix.executor >>

--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -25,7 +25,6 @@ options:
       cimgNodeVersions:
         - '22.13'
         - '20.18'
-        - '18.20'
     '@dotcom-tool-kit/doppler':
       project: repo_n-express
   tasks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@dotcom-tool-kit/node": "^4.2.4",
         "@dotcom-tool-kit/typescript": "^3.2.4",
         "@financial-times/eslint-config-next": "^7.1.0",
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node20": "^20.1.4",
         "@types/express": "5.0.0",
         "@types/isomorphic-fetch": "0.0.39",
         "@types/node": "22.10.7",
@@ -41,7 +41,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": "18.x || 20.x || 22.x"
+        "node": "20.x || 22.x"
       }
     },
     "node_modules/@apaleslimghost/boxen": {
@@ -2103,10 +2103,10 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
+      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9740,10 +9740,10 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tsconfig/node18": {
-      "version": "18.2.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-      "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+    "@tsconfig/node20": {
+      "version": "20.1.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
+      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
       "dev": true
     },
     "@types/body-parser": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@dotcom-tool-kit/node": "^4.2.4",
     "@dotcom-tool-kit/typescript": "^3.2.4",
     "@financial-times/eslint-config-next": "^7.1.0",
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node20": "^20.1.4",
     "@types/express": "5.0.0",
     "@types/isomorphic-fetch": "0.0.39",
     "@types/node": "22.10.7",
@@ -44,7 +44,7 @@
     "n-express-generate-certificate": "bin/n-express-generate-certificate.sh"
   },
   "engines": {
-    "node": "18.x || 20.x || 22.x"
+    "node": "20.x || 22.x"
   },
   "config": {},
   "false": {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
Node.js 18 goes end-of-life in April 2025. We should drop it as part of the next major version.

**Note: this is PRed into the `next` branch which is where we're batching up changes for v32**