### PR TITLE
CPP-2398: add subscription middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 - `withFlags` - decorates each request with [flags](https://github.com/Financial-Times/n-flags-client) as `res.locals.flags`
 - `withConsent` - decorates each request with the user's consent preferences as `res.locals.consent`
 - `withServiceMetrics` - instruments `fetch` to record metrics on services that the application uses. Defaults to `true`
+- `withSubscriptionDetails`- adds middleware that extracts subscription details from headers and sets the `res.locals.subscription` model
 - `withAnonMiddleware`- adds middleware that converts headers related to logged in status in to a `res.locals.anon` model
 - `healthChecks` Array - an array of healthchecks to serve on the `/__health` path (see 'Healthchecks' section below)
 - `healthChecksAppName` String - the name of the application, output in the `/__health` JSON. This defaults to `Next FT.com <appname> in <region>`.

--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ const robots = require('./src/middleware/robots');
 const security = require('./src/middleware/security');
 const vary = require('./src/middleware/vary');
 const logVary = require('./src/middleware/log-vary');
+const subscription = require('./src/middleware/subscription');
 const anon = require('./src/middleware/anon');
 const teapot = fs.readFileSync(
 	path.join(__dirname, 'src/assets/teapot.ascii'),
@@ -150,6 +151,10 @@ const getAppContainer = (options) => {
 
 	if (options.logVary) {
 		app.use(logVary);
+	}
+
+	if (options.withSubscriptionDetails) {
+		app.use(subscription.middleware);
 	}
 
 	if (options.withAnonMiddleware) {

--- a/src/middleware/subscription.js
+++ b/src/middleware/subscription.js
@@ -1,0 +1,87 @@
+const logger = require('@dotcom-reliability-kit/logger');
+
+/**
+ * @import {Callback, Request, Response} from '../../typings/n-express'
+ */
+
+/**
+ * @param {string} header
+ */
+function parseSubscriptionHeader (header) {
+	const headerProperties = header.split(';');
+
+	/**
+	 * If we don't receive the header, we assume the user is anonymous with no access.
+	 * @type {{
+	 * status: 'subscribed' | 'registered' | 'anonymous'
+	 * productCodes?: string[]
+	 * licenceIds?: string[]
+	 * access: { isB2b: boolean, isB2c: boolean, isStaff: boolean }
+	 * }} */
+	const subscriptionDetails = {
+		status: 'anonymous',
+		productCodes: [],
+		licenceIds: [],
+		access: {
+			isB2b: false,
+			isB2c: false,
+			isStaff: false
+		}
+	};
+
+	if (headerProperties.length === 0) {
+		logger.warn({
+			event: 'SUBSCRIPTION_HEADER_MISSING',
+			message: 'The ft-user-subscription header was not received.'
+		});
+
+		return subscriptionDetails;
+	}
+
+	const statusList = new Set(['subscribed', 'registered', 'anonymous']);
+
+	headerProperties.forEach((property) => {
+		const [key, value] = property.split('=').map((s) => s.trim());
+
+		if (!value) return;
+
+		if (
+			(key === 'productCodes' || key === 'licenceIds')
+		) {
+			subscriptionDetails[key] = value.split(',');
+		}
+
+		if (key === 'status' && statusList.has(value)) {
+			subscriptionDetails.status =
+				/** @type {'subscribed' | 'registered' | 'anonymous'} */
+				(value);
+		}
+
+		if (key === 'access') {
+			value.split(',').forEach((flag) => {
+				if (flag in subscriptionDetails.access) {
+					subscriptionDetails.access[
+						/** @type {'isB2b' | 'isB2c' | 'isStaff'} */ (flag)
+					] = true;
+				}
+			});
+		}
+	});
+
+	return subscriptionDetails;
+}
+
+/**
+ * @type {Callback}
+ */
+function subscriptionDetailsMiddleware (req, res, next) {
+	res.locals.subscription = parseSubscriptionHeader(
+		req.get('ft-user-subscription') || ''
+	);
+
+	next();
+}
+
+module.exports = {
+	middleware: subscriptionDetailsMiddleware
+};

--- a/test/middleware/subscription.test.js
+++ b/test/middleware/subscription.test.js
@@ -1,0 +1,105 @@
+const request = require('supertest');
+const nextExpress = require('../../main');
+const expect = require('chai').expect;
+
+describe('Subscription Middleware', function () {
+	let app;
+	let locals;
+
+	before(function () {
+		app = nextExpress({
+			withFlags: true,
+			withHandlebars: false,
+			withAssets: false,
+			withSubscriptionDetails: true,
+			systemCode: 'subscription'
+		});
+		app.get('/', function (req, res) {
+			locals = res.locals;
+			res.sendStatus(200).end();
+		});
+	});
+
+	it('Should set the res.locals.subscription property', function (done) {
+		request(app)
+			.get('/')
+			.expect(function () {
+				expect(locals).to.have.property('subscription');
+			})
+			.end(done);
+	});
+
+	it('Should set the default subscription object if the header is not set', function (done) {
+		request(app)
+			.get('/')
+			.expect(function () {
+				expect(locals.subscription).to.deep.equal({ 		status: 'anonymous',
+					productCodes: [],
+					licenceIds: [],
+					access: {
+						isB2b: false,
+						isB2c: false,
+						isStaff: false
+					}});
+			})
+			.end(done);
+	});
+
+	it('Should include the subscription status', function (done) {
+		request(app)
+			.get('/')
+			.set('ft-user-subscription', 'status=subscribed')
+			.expect(function () {
+				expect(locals.subscription.status).to.equal('subscribed');
+			})
+			.end(done);
+	});
+
+	it('Should include the product codes', function (done) {
+		request(app)
+			.get('/')
+			.set('ft-user-subscription', 'status=subscribed;productCodes=MPR,P2')
+			.expect(function () {
+				expect(locals.subscription.productCodes).to.deep.equal(['MPR', 'P2']);
+			})
+			.end(done);
+	});
+
+	it('Should include the licence ids', function (done) {
+		request(app)
+			.get('/')
+			.set('ft-user-subscription', 'status=subscribed;productCodes=MPR,P2;licenceIds=licence-0001,licence-0002')
+			.expect(function () {
+				expect(locals.subscription.licenceIds).to.deep.equal(['licence-0001', 'licence-0002']);
+			})
+			.end(done);
+	});
+
+	it('Should include only the expected access flags', function (done) {
+		request(app)
+			.get('/')
+			.set('ft-user-subscription', 'status=subscribed;productCodes=MPR,P2;licenceIds=licence-0001,licence-0002;access=isB2c,isStaff,isTrialist')
+
+			.expect(function () {
+				expect(locals.subscription.access).to.deep.equal({ isB2b: false, isB2c: true, isStaff: true });
+			})
+			.end(done);
+	});
+
+	it('Should set an empty array for licence ids or product codes if the value is not present', function (done) {
+		request(app)
+			.get('/')
+			.set('ft-user-subscription', 'status=subscribed;productCodes=;licenceIds=;access=isB2c,isStaff,isTrialist')
+
+			.expect(function () {
+				expect(locals.subscription.licenceIds).to.deep.equal([]);
+				expect(locals.subscription.productCodes).to.deep.equal([]);
+			})
+			.end(done);
+	});
+
+	after(() => {
+		nextExpress.flags.flags.stop();
+		app.close();
+	});
+});

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -44,6 +44,7 @@ export interface AppOptions extends AppMeta {
 	withBackendAuthentication: boolean;
 	withFlags: boolean;
 	withServiceMetrics: boolean;
+	withSubscriptionDetails: boolean;
 }
 
 export interface ErrorRateHealthcheckOptions {


### PR DESCRIPTION
## Description

Extracts the subscription details from the `ft-user-subscription` header, parses it and set the local property `subscription`.

The `ft-user-subscription` header is expected to have this format: 
```
ft-user-subscriptions:status=subscribed;productCodes=P1;access=isB2c,isStaff;licenceIds=008ce617-4453-438a-9760-7c3f3cd3b67f
```
as recently implemented on the [Preflight task](https://github.com/Financial-Times/next-preflight/blob/main/server/tasks/membership/subscription.js#L84-L112).

The anon middleware will be able to read this property to determine the `isUserSubscribed` property, instead of reading from the `ft-user-subscription-status` header, which is set by Ammit API. Although we're expecting apps to migrate to the new subscription object to read the user subscription status.