### PR TITLE
fix!: remove isomorphic-fetch

### DIFF
--- a/.toolkitrc.yml
+++ b/.toolkitrc.yml
@@ -21,6 +21,8 @@ commands:
     - Node
 options:
   plugins:
+    dotcom-tool-kit:
+      allowNativeFetch: true
     '@dotcom-tool-kit/circleci':
       cimgNodeVersions:
         - '22.13'

--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ Various vary headers are set by default (ft-flags, ft-anonymous-user, ft-edition
 - `res.unvaryAll()` - remove all vary headers. *Do not use lightly!!!*
 - `res.vary('My-Header')` - add to the list of vary headers
 
-# Other enhancements
-- `fetch` is added as a global using [isomorphic-fetch](https://github.com/matthew-andrews/isomorphic-fetch)
-
 
 
 # Health checks

--- a/main.js
+++ b/main.js
@@ -19,6 +19,19 @@ const consentMiddleware = require('./src/middleware/consent');
 // logging and monitoring
 const metrics = require('next-metrics');
 const logger = require('@dotcom-reliability-kit/logger');
+const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
+
+if (!global.fetch) {
+	logUnhandledError({
+		error: Object.assign(
+			new Error(
+				'No global fetch method is defined, this may cause unexpected errors. Either remove the --no-experimental-fetch flag and migrate to native fetch, or install isomorphic-fetch explicitly'
+			),
+			{ code: 'MISSING_GLOBAL_FETCH' }
+		)
+	});
+	process.exit(1);
+}
 
 // utils
 const setupHealthEndpoint = require('./src/lib/health-checks');

--- a/main.js
+++ b/main.js
@@ -3,8 +3,6 @@
  * @import {AppContainer, AppOptions, Callback} from './typings/n-express'
  */
 
-require('isomorphic-fetch');
-
 const fs = require('fs');
 const path = require('path');
 const express = require('express');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@dotcom-reliability-kit/serialize-request": "^3.1.1",
         "@financial-times/n-flags-client": "^16.0.0",
         "express": "^4.21.2",
-        "isomorphic-fetch": "^3.0.0",
         "n-health": "^13.1.4",
         "next-metrics": "^13.0.0"
       },
@@ -30,7 +29,6 @@
         "@financial-times/eslint-config-next": "^7.1.0",
         "@tsconfig/node20": "^20.1.4",
         "@types/express": "5.0.0",
-        "@types/isomorphic-fetch": "0.0.39",
         "@types/node": "22.13.10",
         "chai": "^4.5.0",
         "dotcom-tool-kit": "^4.7.0",
@@ -2191,12 +2189,6 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/isomorphic-fetch": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.39.tgz",
-      "integrity": "sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==",
-      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "3.0.0",
@@ -4756,34 +4748,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/jest-diff": {
       "version": "29.7.0",
@@ -7919,11 +7883,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -9973,12 +9932,6 @@
         "@types/send": "*"
       }
     },
-    "@types/isomorphic-fetch": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.39.tgz",
-      "integrity": "sha512-I0gou/ZdA1vMG7t7gMzL7VYu2xAKU78rW9U1l10MI0nn77pEHq3tQqHQ8hMmXdMpBlkxZOorjI4sO594Z3kKJw==",
-      "dev": true
-    },
     "@types/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.0.tgz",
@@ -11922,25 +11875,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
-      }
     },
     "jest-diff": {
       "version": "29.7.0",
@@ -14245,11 +14179,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-url": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@financial-times/n-express",
       "version": "0.0.0",
       "dependencies": {
+        "@dotcom-reliability-kit/log-error": "^5.0.0",
         "@dotcom-reliability-kit/logger": "^3.2.2",
         "@dotcom-reliability-kit/serialize-request": "^3.1.1",
         "@financial-times/n-flags-client": "^16.0.0",
@@ -825,6 +826,66 @@
       "integrity": "sha512-CYF7ZX7gC0dZzA7OVX1HmoRnEFw8qAHJypryHum6oerEZtCOMVy4lnMDM8w6gEIlXvWXyjKas4PD44tHNWKtQg==",
       "engines": {
         "node": "18.x || 20.x || 22.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/log-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-5.0.0.tgz",
+      "integrity": "sha512-hT35/TeuICiHRRDCqc7Eg2CsCEe7roIO/F7jRgJ7X+wnf6X4XwxeECD4ldRcXcPI19XvOMGbsbuvUbGPoDkNHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/logger": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^4.0.0"
+      },
+      "engines": {
+        "node": "20.x || 22.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/app-info": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-4.0.0.tgz",
+      "integrity": "sha512-bGqI4Dmez4c5yIqoVwLVub7Rn6bP9CC0JWUpZQhtrnmR5czLCxc8LqFJwS1YYPeUqWyuMB2SSacxhgnBlgBikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20.x || 22.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/logger": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-4.0.0.tgz",
+      "integrity": "sha512-avgvRd4cqUmn30dm5t8CqtmrHugEeCTTC6CAVVjcF1elEQeuvHYiKaWbNKftVO54kk5LeZ6enV6HDN71tHBYNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
+        "lodash.clonedeep": "^4.5.0",
+        "pino": "^9.6.0"
+      },
+      "engines": {
+        "node": "20.x || 22.x"
+      },
+      "peerDependencies": {
+        "pino-pretty": ">=7.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/serialize-error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-4.0.0.tgz",
+      "integrity": "sha512-nMt/bYRzdFEtq9JM5S6nBL3+UaO+XQTf8mYTPa7Tl7x0A+A31XGnpCcIOite4NekbSaWEVagzJBAK5xaJCklYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20.x || 22.x"
+      }
+    },
+    "node_modules/@dotcom-reliability-kit/log-error/node_modules/@dotcom-reliability-kit/serialize-request": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-4.0.0.tgz",
+      "integrity": "sha512-2EfidEQxTtTl+0wxgpmI3CxjzXpKSTgJ11rY8J+ugV3sd+f2h0e0U06QiOfackgQkUcYImh1jFQVq51NoVI+uw==",
+      "license": "MIT",
+      "engines": {
+        "node": "20.x || 22.x"
       }
     },
     "node_modules/@dotcom-reliability-kit/logger": {
@@ -8885,6 +8946,45 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-3.3.1.tgz",
       "integrity": "sha512-CYF7ZX7gC0dZzA7OVX1HmoRnEFw8qAHJypryHum6oerEZtCOMVy4lnMDM8w6gEIlXvWXyjKas4PD44tHNWKtQg=="
+    },
+    "@dotcom-reliability-kit/log-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/log-error/-/log-error-5.0.0.tgz",
+      "integrity": "sha512-hT35/TeuICiHRRDCqc7Eg2CsCEe7roIO/F7jRgJ7X+wnf6X4XwxeECD4ldRcXcPI19XvOMGbsbuvUbGPoDkNHg==",
+      "requires": {
+        "@dotcom-reliability-kit/app-info": "^4.0.0",
+        "@dotcom-reliability-kit/logger": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-error": "^4.0.0",
+        "@dotcom-reliability-kit/serialize-request": "^4.0.0"
+      },
+      "dependencies": {
+        "@dotcom-reliability-kit/app-info": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/app-info/-/app-info-4.0.0.tgz",
+          "integrity": "sha512-bGqI4Dmez4c5yIqoVwLVub7Rn6bP9CC0JWUpZQhtrnmR5czLCxc8LqFJwS1YYPeUqWyuMB2SSacxhgnBlgBikQ=="
+        },
+        "@dotcom-reliability-kit/logger": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/logger/-/logger-4.0.0.tgz",
+          "integrity": "sha512-avgvRd4cqUmn30dm5t8CqtmrHugEeCTTC6CAVVjcF1elEQeuvHYiKaWbNKftVO54kk5LeZ6enV6HDN71tHBYNw==",
+          "requires": {
+            "@dotcom-reliability-kit/app-info": "^4.0.0",
+            "@dotcom-reliability-kit/serialize-error": "^4.0.0",
+            "lodash.clonedeep": "^4.5.0",
+            "pino": "^9.6.0"
+          }
+        },
+        "@dotcom-reliability-kit/serialize-error": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-error/-/serialize-error-4.0.0.tgz",
+          "integrity": "sha512-nMt/bYRzdFEtq9JM5S6nBL3+UaO+XQTf8mYTPa7Tl7x0A+A31XGnpCcIOite4NekbSaWEVagzJBAK5xaJCklYQ=="
+        },
+        "@dotcom-reliability-kit/serialize-request": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@dotcom-reliability-kit/serialize-request/-/serialize-request-4.0.0.tgz",
+          "integrity": "sha512-2EfidEQxTtTl+0wxgpmI3CxjzXpKSTgJ11rY8J+ugV3sd+f2h0e0U06QiOfackgQkUcYImh1jFQVq51NoVI+uw=="
+        }
+      }
     },
     "@dotcom-reliability-kit/logger": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@dotcom-reliability-kit/serialize-request": "^3.1.1",
     "@financial-times/n-flags-client": "^16.0.0",
     "express": "^4.21.2",
-    "isomorphic-fetch": "^3.0.0",
     "n-health": "^13.1.4",
     "next-metrics": "^13.0.0"
   },
@@ -30,7 +29,6 @@
     "@financial-times/eslint-config-next": "^7.1.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/express": "5.0.0",
-    "@types/isomorphic-fetch": "0.0.39",
     "@types/node": "22.13.10",
     "chai": "^4.5.0",
     "dotcom-tool-kit": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "dotcom-tool-kit run:local"
   },
   "dependencies": {
+    "@dotcom-reliability-kit/log-error": "^5.0.0",
     "@dotcom-reliability-kit/logger": "^3.2.2",
     "@dotcom-reliability-kit/serialize-request": "^3.1.1",
     "@financial-times/n-flags-client": "^16.0.0",

--- a/test/app/missing-fetch.test.js
+++ b/test/app/missing-fetch.test.js
@@ -1,0 +1,16 @@
+/*global it, describe*/
+const exec = require('node:child_process').exec;
+const expect = require('chai').expect;
+const { join } = require('node:path');
+
+describe('app with missing fetch', function () {
+	it('logs a fatal error and exits the process', function (done) {
+		const appPath = join(__dirname, '..', 'fixtures', 'app', 'main.js');
+		exec(`node --no-experimental-fetch ${appPath}`, (error, stdout) => {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.code).to.equal(1);
+			expect(stdout).to.contain('UNHANDLED_ERROR');
+			done();
+		});
+	});
+});


### PR DESCRIPTION
> [!NOTE]
> This is PRed into the `next` branch, where we're gathering code for v32 of n-express. See #885  

Since Node.js 18, a global `fetch` has been available. The `fetch` implementation provided by isomorphic-fetch is not spec-compliant which makes migrating away from it a pain. We decided a starting point for this migration is to move the decision about installing isomorphic-fetch from this shared library and into the systems themselves.

Apps updating to this version of n-express will need to either switch to using Node.js global `fetch` _or_ introduce isomorphic-fetch explicitly.

n-express makes no `fetch` calls of its own so there's no need to import another fetch library like `undici` here.

Closes #838