### PR TITLE
CPP-2397: Derive isUserSubscribed property from ft-user-subscription header

### DIFF
--- a/test/middleware/anon.test.js
+++ b/test/middleware/anon.test.js
@@ -41,10 +41,24 @@ describe('Anonymous Middleware', function () {
 			.end(done);
 	});
 
-	it('Should set the res.locals.userIsSubscribed property based on the ft-user-subscription-status header', function (done) {
+	it('Should set the res.locals.userIsSubscribed property based on the ft-user-subscription header', function (done) {
 		request(app)
 			.get('/')
 			.set('FT-Anonymous-User', 'false')
+			.set('ft-user-subscription', 'status=subscribed;productCodes=;licenceIds=;access=isB2c,isStaff,isTrialist')
+			.expect(function () {
+				expect(locals.anon.userIsAnonymous).to.be.false;
+				expect(locals.anon.userIsLoggedIn).to.be.true;
+				expect(locals.anon.userIsSubscribed).to.be.true;
+			})
+			.end(done);
+	});
+
+	it('Should set the res.locals.userIsSubscribed property should fallback to ft-user-subscription-status if there is an issue with the ft-user-subscription-header', function (done) {
+		request(app)
+			.get('/')
+			.set('FT-Anonymous-User', 'false')
+			.set('ft-user-subscription', 'status=anonymous')
 			.set('ft-user-subscription-status', 'subscribed')
 			.expect(function () {
 				expect(locals.anon.userIsAnonymous).to.be.false;


### PR DESCRIPTION
## Description

Extracts the user subscription status from the `ft-user-subscription` header and uses it to set the `isUserSubscribed` property. 

The `ft-user-subscription` header [should always be set](https://github.com/Financial-Times/ft.com-cdn/blob/3ef5c860e390fe882e51a2a63134566cf53b4112/src/vcl/next-preflight.vcl#L67) for apps behind the FT.com CDN. However, we’re considering cases where it might be missing or have an incorrect value. In those scenarios, we log a warning and fall back to the previous `ft-user-subscription-status` header. This will allow us to detect issues with the new header before removing the old one.

The `ft-user-subscription-status` is currently being set by Ammit API, our deprecated flags system. The new `ft-user-subscription` header contains the user subscription details without relying on Ammit API flags, allowing us to decouple FT.com features that depend on the `ft-user-subscription-status` header or other subscription data from Ammit API.
