### PR TITLE
remove addInitPromises

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Passed in to `nExpress`, these (Booleans defaulting to false unless otherwise st
 - `getAppContainer()` - returns an object:
 	- `app`: the express app instance
 	- `meta`: object containing the name, description and directory of the app
-	- `addInitPromise()`: function for adding additional promises to wait for before allowing the app to accept traffic
 
 
 ## Cache control

--- a/main.js
+++ b/main.js
@@ -150,7 +150,7 @@ const getAppContainer = (options) => {
 		app.use(anon.middleware);
 	}
 
-	return { app, meta, addInitPromise };
+	return { app, meta };
 };
 
 /**

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -57,7 +57,6 @@ export interface AppContainer {
 	meta: guessAppDetails.Options & {
 		description: string;
 	};
-	addInitPromise: (...items: Promise<any>[]) => number;
 }
 
 // TODO Overload Express.Application methods to use NextApplication


### PR DESCRIPTION
this is currently [not used by anything outside of `n-express`](https://github.com/search?q=org%3AFinancial-Times+addinitpromise+-is%3Aarchived&type=code), and we want to get rid of this eventually, so let's prevent people doing this