### PR TITLE
feat: remove default error middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@dotcom-reliability-kit/log-error": "^5.0.2",
         "@dotcom-reliability-kit/logger": "^4.0.1",
-        "@dotcom-reliability-kit/serialize-request": "^4.0.0",
         "@financial-times/n-flags-client": "^16.0.0",
         "express": "^4.21.2",
         "n-health": "^14.0.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@dotcom-reliability-kit/log-error": "^5.0.2",
     "@dotcom-reliability-kit/logger": "^4.0.1",
-    "@dotcom-reliability-kit/serialize-request": "^4.0.0",
     "@financial-times/n-flags-client": "^16.0.0",
     "express": "^4.21.2",
     "n-health": "^14.0.4",

--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -5,8 +5,6 @@ const http = require('http');
 const https = require('https');
 const path = require('path');
 const {readFile} = require('fs/promises');
-const {STATUS_CODES} = http;
-const serializeRequest = require('@dotcom-reliability-kit/serialize-request');
 
 module.exports = class InstrumentListen {
 	constructor (app, meta, initPromises) {
@@ -34,46 +32,6 @@ module.exports = class InstrumentListen {
 
 	initApp (meta, initPromises) {
 		this.app.listen = async (port, callback) => {
-			// these middleware are attached in .listen so they're
-			// definitely after any middleware added by the app itself
-
-			// Optional fallthrough error handler
-			// eslint-disable-next-line no-unused-vars
-			this.app.use((err, req, res, next) => {
-				let statusCode = parseInt(err.statusCode || err.status || 500, 10);
-
-				// There's clearly an error, so if the error has a status
-				// code of less than `400` we should default to `500` to
-				// ensure bad error handling doesn't send false positive
-				// status codes. We also check that the status code is
-				// a valid number.
-				const isValidErrorStatus = (
-					!Number.isNaN(statusCode) && // Possible if `error.status` is something unexpected, like an object
-					statusCode >= 400 &&
-					statusCode <= 599
-				);
-
-				res.statusCode = isValidErrorStatus ? statusCode : 500;
-				const statusMessage = STATUS_CODES[res.statusCode] || STATUS_CODES[500];
-
-				// If headers have been sent already then we need to hand off to
-				// the final Express error handler as documented here:
-				// https://expressjs.com/en/guide/error-handling.html#the-default-error-handler
-				//
-				// This ensures that the app doesn't crash with `ERR_STREAM_WRITE_AFTER_END`
-				if (res.headersSent) {
-					logger.warn({
-						event: 'EXPRESS_ERROR_HANDLER_FAILURE',
-						message: 'The default n-express error handler could not output because the response has already been sent',
-						request: serializeRequest(req)
-					}, err);
-					return next(err);
-				}
-
-				const output = `${res.statusCode} ${statusMessage}\n`;
-				res.end(output);
-			});
-
 			function wrappedCallback () {
 				// HACK: Use warn so that it gets into Splunk logs
 				logger.warn({


### PR DESCRIPTION
a) everything this middleware does, the default express error handler does (we used to do Raven/Sentry error logging here)
b) also, @dotcom-reliability-kit/middleware-render-error-info