### PR TITLE
feat!: support express v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "node": "20.x || 22.x"
       },
       "peerDependencies": {
-        "express": "^4.21.2"
+        "express": "^4.21.2 || 5.x"
       }
     },
     "node_modules/@apaleslimghost/boxen": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "next-metrics": "^13.0.0"
   },
   "peerDependencies": {
-    "express": "^4.21.2"
+    "express": "^4.21.2 || 5.x"
   },
   "devDependencies": {
     "@dotcom-tool-kit/component": "^5.1.13",


### PR DESCRIPTION
this is a breaking change, as apps currently aren't explicitly depending on any version of Express, and so would be switching to v5 when updating to a version of `n-express` with this change.