### PR TITLE
fix: remove the withAb option entirely

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,6 @@ const consentMiddleware = require('./src/middleware/consent');
 
 // logging and monitoring
 const metrics = require('next-metrics');
-const logger = require('@dotcom-reliability-kit/logger');
 const { logUnhandledError } = require('@dotcom-reliability-kit/log-error');
 
 if (!global.fetch) {
@@ -70,13 +69,6 @@ const getAppContainer = (options) => {
 		throw new Error(
 			'All applications must specify a Biz Ops `systemCode` to the express() function. See the README for more details.'
 		);
-	}
-
-	if (options.withAb) {
-		logger.warn({
-			event: 'WITHAB_OPTION_DEPRECATED',
-			message: 'The \'withAb\' option is deprecated and no longer supported by n-express or n-flags-client'
-		});
 	}
 
 	const meta = guessAppDetails(options);

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -32,8 +32,6 @@ export interface AppMeta {
 	systemCode: string;
 }
 export interface AppOptions extends AppMeta {
-	/** @deprecated */
-	withAb?: boolean;
 	healthChecksAppName?: string;
 	healthChecks: Metrics.Healthcheck[];
 	errorRateHealthcheck?: ErrorRateHealthcheckOptions;


### PR DESCRIPTION
This option does nothing except output a log, it wasn't really deprecated it was just not working any more. The only potential breaking change here is if a TypeScript project is referencing this option but it's unused across the whole FT TypeScript estate.

I searched Splunk for `WITHAB_OPTION_DEPRECATED` over the last quarter and the only results are next-subscribe and next-retention. These don't have type checking but I'm gonna go remove the reference anyway.