### PR TITLE
Simplify the `robots.txt` middleware

### DIFF
--- a/src/assets/robots.txt
+++ b/src/assets/robots.txt
@@ -1,5 +1,0 @@
-User-agent: Twitterbot
-Disallow:
- 
-User-agent: *
-Disallow: /

--- a/src/middleware/robots.js
+++ b/src/middleware/robots.js
@@ -2,19 +2,18 @@
  * @import {Callback} from '../../typings/n-express'
  */
 
-const fs = require('fs');
-const path = require('path');
-const robots = fs.readFileSync(path.join(__dirname, '../assets/robots.txt'), {
-	encoding: 'utf8'
-});
+const headers = {
+	'Content-Type': 'text/plain',
+	'Cache-Control': `public, max-age=${60 * 60 * 24 * 30}` // One month
+};
 
-/**
- * @type {Callback}
- */
-module.exports = (_req, res) => {
-	res.set({
-		'Content-Type': 'text/plain',
-		'Cache-Control': 'max-age:3600, public'
-	});
-	res.send(robots);
+// This is a string rather than a separate file because we don't want
+// this fallback robots.txt file to be modified or added to. This is
+// used to block good bots from crawling our apps directly and should
+// not be used to grant access - that's the job of the CDN.
+const content = 'User-agent: *\nDisallow: /\n';
+
+/** @type {Callback} */
+module.exports = function robots (_request, response) {
+	response.set(headers).send(content);
 };


### PR DESCRIPTION
We questioned whether this was useful as part of our n-express audit: https://financialtimes.atlassian.net/wiki/spaces/CPP/database/8965226525

We serve a full `robots.txt` on FT.com via the CDN so we wondered whether this was redundant, however it's important that we don't allow crawlers to index systems that are accessed directly and do not use a backend key.

We need to keep this, but I think we can simplify a little:

  * I removed the "Allow Twitterbot" rule - The original commit here 4bc78b9883dfe20116827a9a76758ae8b465a2ef does not explain why it was added, if this causes an issue then we can rethink but at the moment I can't imagine a use-case for us wanting Twitter link previews for any of our apps direct from the Heroku/Hako app URLs.

  * I fixed the cache-control header (`max-age` requires an equals and not a colon) added in 7a3ed3ca72299c5eabd156a9bc519c0276f284eb. I think this never worked. I also increased the cache time from one hour to 30 days because we never change this.

  * I moved directives from a file into the middleware itself as a string. I don't want to encourage editing this and we can save some admittedly small sync file operations during startup. Every little helps eh?