### PR TITLE
Remove the `EXPRESS_START` warning

### DIFF
--- a/src/lib/instrument-listen.js
+++ b/src/lib/instrument-listen.js
@@ -1,6 +1,5 @@
 // @ts-nocheck
 
-const logger = require('@dotcom-reliability-kit/logger');
 const http = require('http');
 const https = require('https');
 const path = require('path');
@@ -32,27 +31,11 @@ module.exports = class InstrumentListen {
 
 	initApp (meta, initPromises) {
 		this.app.listen = async (port, callback) => {
-			function wrappedCallback () {
-				// HACK: Use warn so that it gets into Splunk logs
-				logger.warn({
-					event: 'EXPRESS_START',
-					message: `Express application ${meta.name} started`,
-					app: meta.name,
-					port: port,
-					nodeVersion: process.version
-				});
-
-				if (callback) {
-					return callback.apply(this, arguments);
-				}
-			}
-
 			try {
 				await Promise.all(initPromises);
-
 				const server = await this.createServer();
 				this.server = server;
-				return server.listen(port, wrappedCallback);
+				return server.listen(port, callback);
 			} catch (err) {
 				// crash app if initPromises fail by throwing an error asynchronously outside of the promise
 				// TODO: better error handling


### PR DESCRIPTION
This has always been a hack and it's not very useful, just a spammy log at the wrong level. I don't think it's a breaking change, as far as I know we're not using this in any monitoring. If an app wants to log on startup then it's still possible by providing a callback.

Done as part of the n-express audit:
https://financialtimes.atlassian.net/wiki/spaces/CPP/database/8965226525