### PR TITLE
Skip anon middleware for non-Preflight requests

### DIFF
--- a/src/middleware/anon.js
+++ b/src/middleware/anon.js
@@ -88,6 +88,19 @@ function showFirstClickFree (req, res) {
  * @type {Callback}
  */
 function anonymousMiddleware (req, res, next) {
+	// Skip for static assets, healthchecks, etc.
+	// These routes shouldn't need the anonymous status
+	if (req.path.indexOf('/__') === 0) {
+		return next();
+	}
+
+	// Skip for POST, PUT requests
+	// These routes skip preflight
+	// https://github.com/Financial-Times/ft.com-cdn/blob/327f373f99c88490d54f8fc7e899e03a2fbc7c10/src/vcl/next-preflight.vcl#L99-L102
+	if (req.method === 'POST' || req.method === 'PUT') {
+		return next();
+	}
+
 	res.locals.anon = new anonModels.AnonymousModel(req);
 	res.locals.firstClickFreeModel = showFirstClickFree(req, res)
 		? new anonModels.FirstClickFreeModel()

--- a/test/middleware/anon.test.js
+++ b/test/middleware/anon.test.js
@@ -18,6 +18,45 @@ describe('Anonymous Middleware', function () {
 			locals = res.locals;
 			res.sendStatus(200).end();
 		});
+		app.get('/__gtg', function (req, res) {
+			locals = res.locals;
+			res.sendStatus(200).end();
+		});
+		app.post('/', function (req, res) {
+			locals = res.locals;
+			res.sendStatus(200).end();
+		});
+		app.put('/', function (req, res) {
+			locals = res.locals;
+			res.sendStatus(200).end();
+		});
+	});
+
+	it('Should not set the properties for requests with __ prefix', function (done) {
+		request(app)
+			.get('/__gtg')
+			.expect(function () {
+				expect(locals).not.to.have.property('anon');
+			})
+			.end(done);
+	});
+
+	it('Should not set the properties for POST requests', function (done) {
+		request(app)
+			.post('/')
+			.expect(function () {
+				expect(locals).not.to.have.property('anon');
+			})
+			.end(done);
+	});
+
+	it('Should not set the properties for PUT requests', function (done) {
+		request(app)
+			.put('/')
+			.expect(function () {
+				expect(locals).not.to.have.property('anon');
+			})
+			.end(done);
 	});
 
 	it('Should set the res.locals.anon property', function (done) {


### PR DESCRIPTION
## Description

Releasing the current version of this middleware caused some apps to unexpectetly log a [high volume](https://financialtimes.atlassian.net/browse/CPP-2551) of `SUBSCRIPTION_HEADER_MISSING` warning logs, concretely on [next-control-centre](https://github.com/Financial-Times/next-control-centre). We believe that these might be coming from requests that don't go through Preflight, so therefore don't get a a valid `ft-user-subscription` header.  
 
To mitigate this, we're skipping this middleware logic on requests that are with prefixed with  `__`. These include assets, healthchecks, etc. 

We're also skipping `POST` and `PUT` requests as these also [skip Preflight](https://github.com/Financial-Times/ft.com-cdn/blob/dafd68b65a27b90352e34f0b00b38b0decbf86b8/src/vcl/next-preflight.vcl#L99-L102).

Releasing this version on `next-control-centre` and checking if the it doesn't log a high volume of these warnings should confirm if this fix worked as expected.

