### PR TITLE
CPP-2597 chore: remove references to legacy firstClickfreeModel from anon midd…

### DIFF
--- a/src/middleware/anon.js
+++ b/src/middleware/anon.js
@@ -63,26 +63,14 @@ function getSubscriptionStatus (req) {
 	return userSubscriptionStatus;
 }
 
-function FirstClickFreeModel () {
-	this.signInLink = '/login';
-}
-
 const anonModels = {
 	AnonymousModel: AnonymousModel,
-	FirstClickFreeModel: FirstClickFreeModel
 };
 
 /**
  * @param {Request} req
  * @param {Response} res
  */
-function showFirstClickFree (req, res) {
-	return (
-		res.locals.flags.firstClickFree &&
-		req.get('FT-Access-Decision') === 'GRANTED' &&
-		req.get('FT-Access-Decision-Policy') === 'PRIVILEGED_REFERER_POLICY'
-	);
-}
 
 /**
  * @type {Callback}
@@ -102,10 +90,6 @@ function anonymousMiddleware (req, res, next) {
 	}
 
 	res.locals.anon = new anonModels.AnonymousModel(req);
-	res.locals.firstClickFreeModel = showFirstClickFree(req, res)
-		? new anonModels.FirstClickFreeModel()
-		: null;
-
 	res.vary('FT-Anonymous-User');
 	next();
 }

--- a/test/middleware/anon.test.js
+++ b/test/middleware/anon.test.js
@@ -107,19 +107,6 @@ describe('Anonymous Middleware', function () {
 			.end(done);
 	});
 
-	it('Should provide a firstClickFree model when required', function (done) {
-		request(app)
-			.get('/')
-			.set('FT-Access-Decision', 'GRANTED')
-			.set('FT-Access-Decision-Policy', 'PRIVILEGED_REFERER_POLICY')
-			.set('FT-Flags', 'firstClickFree:on')
-			.expect(function () {
-				expect(locals.firstClickFreeModel).to.be.an('object');
-				expect(locals.firstClickFreeModel).to.have.property('signInLink');
-			})
-			.end(done);
-	});
-
 	after(() => {
 		nextExpress.flags.flags.stop();
 		app.close();


### PR DESCRIPTION
…leware and tests

[CPP-2597](https://financialtimes.atlassian.net/browse/CPP-2597)

This PR removes references to the legacy property `firstClickFreeModel` from the annon middleware and tests. 

[CPP-2597]: https://financialtimes.atlassian.net/browse/CPP-2597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ