### PR TITLE
Explicitly name all middleware functions to improve OpenTelemetry spans

### DIFF
--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ const getAppContainer = (options) => {
 
 	// Debug related headers.
 	app.use(
-		/** @type {Callback} */ (req, res, next) => {
+		/** @type {Callback} */ function setDebugHeaders (req, res, next) {
 			res.set('FT-App-Name', meta.name);
 			res.set('FT-Backend-Timestamp', new Date().toISOString());
 			res.set('FT-System-Code', meta.systemCode);

--- a/src/middleware/consent.js
+++ b/src/middleware/consent.js
@@ -5,7 +5,7 @@
 /**
  * @type {Callback}
  */
-module.exports = (req, res, next) => {
+const consent = (req, res, next) => {
 	res.locals = res.locals || {};
 	res.locals.consent = res.locals.consent || {};
 
@@ -28,3 +28,5 @@ module.exports = (req, res, next) => {
 	}
 	next();
 };
+
+module.exports = consent;

--- a/src/middleware/security.js
+++ b/src/middleware/security.js
@@ -5,9 +5,10 @@
 /**
  * @type {Callback}
  */
-module.exports = (_req, res, next) => {
+const security = (_req, res, next) => {
 	res.set('X-Content-Type-Options', 'nosniff');
 	res.set('X-Download-Options', 'noopen');
 	res.set('X-XSS-Protection', '1; mode=block');
 	next();
 };
+module.exports = security;

--- a/src/middleware/vary.js
+++ b/src/middleware/vary.js
@@ -18,7 +18,7 @@ const extendVary = (val, set) => {
 /**
  * @type {Callback}
  */
-module.exports = (_req, res, next) => {
+const vary = (_req, res, next) => {
 	const resSet = res.set;
 
 	/** @type {Set<string>} */
@@ -74,3 +74,5 @@ module.exports = (_req, res, next) => {
 
 	next();
 };
+
+module.exports = vary;


### PR DESCRIPTION
OpenTelemetry will [use](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/e9987a7980ec13d21c7ce6ee37988d7c1517c671/packages/instrumentation-express/src/utils.ts#L115) these function names in its spans so it can be easier to see what's happening in a request trace when all the middleware are named rather than labelled `anonymous`.

This will improve the traces currently accessible through AWS CloudWatch traces in apps consuming the updated version of n-express. Here's an example segment as of now:

<img width="487" height="570" alt="Screenshot 2025-07-22 at 18 05 35" src="https://github.com/user-attachments/assets/bc9091ec-b643-4304-8e43-2e71b772258c" />
