### PR TITLE
Am/deprecate props

### DIFF
--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -1,9 +1,8 @@
-import Metrics from '@financial-times/n-metrics';
 import Express from 'express';
 import http from 'http';
 import https from 'https';
 import { cacheHeaders } from '../src/middleware/cache';
-export * from './metrics';
+import type { Healthcheck } from './metrics';
 
 export type CacheHeaders = typeof cacheHeaders;
 
@@ -35,7 +34,7 @@ export interface AppMeta {
 }
 export interface AppOptions extends AppMeta {
 	healthChecksAppName?: string;
-	healthChecks: Metrics.Healthcheck[];
+	healthChecks: Healthcheck[];
 	demo?: boolean;
 	withAnonMiddleware?: boolean;
 	withConsent: boolean;
@@ -46,7 +45,7 @@ export interface AppOptions extends AppMeta {
 
 export interface AppContainer {
 	app: Express.Application;
-	meta: guessAppDetails.Options & {
+	meta: AppMeta & {
 		description: string;
 	};
 	addInitPromise: (...items: Promise<any>[]) => number;
@@ -65,7 +64,7 @@ declare namespace express {
 	declare const json: Express.json;
 	declare const Router = Express.Router;
 	declare const static: Express.static;
-	declare const metrics: Metrics;
+	declare const metrics: unknown;
 	declare const flags: flags;
 	declare const getAppContainer: getAppContainer;
 }

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -42,7 +42,6 @@ export interface AppOptions extends AppMeta {
 	withConsent: boolean;
 	withBackendAuthentication: boolean;
 	withFlags: boolean;
-	withServiceMetrics: boolean;
 }
 
 export interface ErrorRateHealthcheckOptions {

--- a/typings/n-express.d.ts
+++ b/typings/n-express.d.ts
@@ -36,7 +36,6 @@ export interface AppMeta {
 export interface AppOptions extends AppMeta {
 	healthChecksAppName?: string;
 	healthChecks: Metrics.Healthcheck[];
-	errorRateHealthcheck?: ErrorRateHealthcheckOptions;
 	demo?: boolean;
 	withAnonMiddleware?: boolean;
 	withConsent: boolean;
@@ -44,11 +43,6 @@ export interface AppOptions extends AppMeta {
 	withFlags: boolean;
 }
 
-export interface ErrorRateHealthcheckOptions {
-	severity?: number;
-	threshold?: number;
-	samplePeriod?: string;
-}
 
 export interface AppContainer {
 	app: Express.Application;


### PR DESCRIPTION
## What's changed

Per conversation with @rowanmanning, we could deprecate `errorRateHealthcheck` & `withServiceMetrics`. See [Slack](https://financialtimes.slack.com/archives/C02B89GEQHF/p1772041311911639)

I also spotted import issues in my IDE. I took the liberty to fix them, however, I am not entirely sure if that's safe to do.

* `@financial-times/n-metrics` is not longer a part of this project.
* `guessAppDetails` is not imported and can be replaced by `AppMeta`